### PR TITLE
Fix memory leaks in Figure.destroy() teardown

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Releases
 
+## 1.1.2
+* Fix memory leaks in `Figure.destroy()`: store bound scroll listener so `disableScrolling()` actually removes it, add `Recorder.cleanup()` to detach audio/worker listeners and clear timers, remove HTMLObject DOM elements and free VertexText canvas backing store on cleanup, delegate texture deletion to `webgl.deleteTexture()` for complete GL resource release
+
 ## 1.1.1
 * Fix orphaned WebGL buffers from equation layout's internal text measurement element that was never cleaned up on destroy
 * Plumb `deleteTexture` parameter through the element cleanup chain so shared atlas textures are preserved during partial cleanup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/DrawingObjects/GLObject/GLObject.ts
+++ b/src/js/figure/DrawingObjects/GLObject/GLObject.ts
@@ -569,17 +569,13 @@ class GLObject extends DrawingObject {
   resetTextureBuffer(deleteTexture: boolean = true) {
     const { texture, webgl, gl } = this;
     if (texture) {
-      if (deleteTexture && webgl.textures[texture.id].glTexture != null) {
-        gl.activeTexture(gl.TEXTURE0 + webgl.textures[texture.id].index);
-        gl.bindTexture(gl.TEXTURE_2D, null);
-        // gl.deleteTexture(webgl.textures[texture.id].glTexture);
-        webgl.textures[texture.id].glTexture = null as any;
+      if (deleteTexture && webgl.textures[texture.id] != null) {
+        webgl.deleteTexture(texture.id);
       }
       if (texture.buffer != null) {
         gl.deleteBuffer(texture.buffer);
         texture.buffer = null;
       }
-      // texture.glTexture = null;
     }
   }
 

--- a/src/js/figure/DrawingObjects/HTMLObject/HTMLObject.ts
+++ b/src/js/figure/DrawingObjects/HTMLObject/HTMLObject.ts
@@ -168,6 +168,12 @@ class HTMLObject extends DrawingObject {
     }
   }
 
+  override cleanup() {
+    if (this.element && this.element.parentNode) {
+      this.element.parentNode.removeChild(this.element);
+    }
+  }
+
   override drawWithTransformMatrix(scene: Scene, worldMatrix: Type3DMatrix, color: TypeColor) {
     let isDifferent = false;
     const transformMatrix = m3.mul(scene.viewProjectionMatrix, worldMatrix);

--- a/src/js/figure/DrawingObjects/VertexObject/VertexText.ts
+++ b/src/js/figure/DrawingObjects/VertexObject/VertexText.ts
@@ -94,6 +94,16 @@ class VertexText extends VertexGeneric {
   }
 
 
+  override cleanup(deleteTexture: boolean = true) {
+    // Free the 2D canvas backing store before parent deletes GL buffers
+    if (this.canvas) {
+      this.canvas.width = 0;
+      this.canvas.height = 0;
+    }
+    this.ctx = null;
+    super.cleanup(deleteTexture);
+  }
+
   // Text is positioned such that the text baseline will be at
   // vertex space y = 0.
   // The border will then cover the ascent and descent of the text.

--- a/src/js/figure/Equation/__snapshots__/Equation.use.test.ts.snap
+++ b/src/js/figure/Equation/__snapshots__/Equation.use.test.ts.snap
@@ -758,6 +758,8 @@ FigureElementPrimitive2DText {
   },
   "pulseTransforms": [],
   "recorder": Recorder {
+    "_audioHandlers": null,
+    "_boundParseMessage": null,
     "audio": null,
     "currentTime": 0,
     "duration": 0,

--- a/src/js/figure/Figure.ts
+++ b/src/js/figure/Figure.ts
@@ -388,6 +388,7 @@ class Figure {
   _boundFocusLost!: EventListener;
   _boundContextLost!: EventListener;
   _boundContextRestored!: EventListener;
+  _boundScrollEvent!: EventListener;
 
   constructor(options: OBJ_Figure = {}) {
     const defaultOptions = {
@@ -772,6 +773,7 @@ class Figure {
     this._boundResize = this.resize.bind(this) as unknown as EventListener;
     this._boundFocusGained = this.focusGained.bind(this) as EventListener;
     this._boundFocusLost = this.focusLost.bind(this) as EventListener;
+    this._boundScrollEvent = this.scrollEvent.bind(this) as EventListener;
     window.addEventListener('resize', this._boundResize);
     window.addEventListener('focus', this._boundFocusGained);
     window.addEventListener('blur', this._boundFocusLost);
@@ -974,7 +976,7 @@ class Figure {
   enableScrolling() {
     document.addEventListener(
       'scroll',
-      this.scrollEvent.bind(this),
+      this._boundScrollEvent,
       false,
     );
   }
@@ -982,7 +984,7 @@ class Figure {
   disableScrolling() {
     document.removeEventListener(
       'scroll',
-      this.scrollEvent.bind(this),
+      this._boundScrollEvent,
       false,
     );
   }
@@ -1507,16 +1509,27 @@ class Figure {
     // Remove gesture listeners (canvas + window)
     this.gesture.destroy();
 
-    // Remove window listeners
+    // Remove window/document listeners
     window.removeEventListener('resize', this._boundResize);
     window.removeEventListener('focus', this._boundFocusGained);
     window.removeEventListener('blur', this._boundFocusLost);
+    this.disableScrolling();
 
     // Remove canvas listeners (only set when webgl !== 'manual')
     if (this.canvasLow && this._boundContextLost) {
       this.canvasLow.removeEventListener('webglcontextlost', this._boundContextLost, false);
       this.canvasLow.removeEventListener('webglcontextrestored', this._boundContextRestored, false);
     }
+
+    // Clear pending timers
+    if (this.scrollTimeoutId) {
+      clearTimeout(this.scrollTimeoutId);
+      this.scrollTimeoutId = null;
+    }
+    this.clearDrawTimeout();
+
+    // Clean up recorder (audio listeners, worker, timeouts)
+    this.recorder.cleanup();
 
     // Clean up all elements recursively (notifications, drawing objects, children)
     this.elements.cleanup();

--- a/src/js/figure/Recorder/Recorder.ts
+++ b/src/js/figure/Recorder/Recorder.ts
@@ -295,6 +295,8 @@ class Recorder {
   };
 
   worker!: any;
+  _boundParseMessage!: ((event: MessageEvent) => void) | null;
+  _audioHandlers!: { pause: () => void; play: () => void; playing: () => void; ended: () => void } | null;
 
   // static instance: Object;
 
@@ -329,6 +331,44 @@ class Recorder {
     this.queueSeekId = null;
     // this.useAutoEvents = false;
     this.timeUpdates = 100; // ms
+    this._boundParseMessage = null;
+    this._audioHandlers = null;
+  }
+
+  cleanupAudio() {
+    if (this.audio && this._audioHandlers) {
+      this.audio.removeEventListener('pause', this._audioHandlers.pause);
+      this.audio.removeEventListener('play', this._audioHandlers.play);
+      this.audio.removeEventListener('playing', this._audioHandlers.playing, false);
+      this.audio.removeEventListener('ended', this._audioHandlers.ended, false);
+      this.audio.onloadedmetadata = null;
+      this.audio.oncanplaythrough = null;
+    }
+    this._audioHandlers = null;
+  }
+
+  cleanup() {
+    this.cleanupAudio();
+    this.audio = null;
+    if (this.worker && this._boundParseMessage) {
+      this.worker.removeEventListener('message', this._boundParseMessage);
+      this.worker.terminate();
+    }
+    this.worker = null;
+    this._boundParseMessage = null;
+    if (this.timeoutID != null) {
+      this.timeKeeper.clearTimeout(this.timeoutID);
+      this.timeoutID = null;
+    }
+    if (this.timeUpdatesTimeoutID != null) {
+      this.timeKeeper.clearTimeout(this.timeUpdatesTimeoutID);
+      this.timeUpdatesTimeoutID = null;
+    }
+    if (this.queueSeekId != null) {
+      this.timeKeeper.clearTimeout(this.queueSeekId);
+      this.queueSeekId = null;
+    }
+    this.notifications.cleanup();
   }
 
   // ////////////////////////////////////
@@ -439,6 +479,7 @@ class Recorder {
   }
 
   loadAudioTrack(audio: HTMLAudioElement) {
+    this.cleanupAudio();
     this.audio = audio;
     this.audio.onloadedmetadata = () => {
       this.duration = this.calcDuration();
@@ -447,20 +488,26 @@ class Recorder {
     this.audio.oncanplaythrough = () => {
       this.notifications.publish('audioLoaded');
     };
-    this.audio.addEventListener('pause', () => {
-      if (this.state === 'playing') {
-        this.pausePlayback();
-      }
-    });
-    this.audio.addEventListener('play', () => {
-      // This is here to handle audio triggered start/stop (like headphones
-      // being removed or inserted)
-      if (this.state === 'idle' && this.audioStartedCallback == null) {
-        this.resumePlayback();
-      }
-    });
-    audio.addEventListener('playing', () => this.audioStarted(), false);
-    audio.addEventListener('ended', () => this.audioEnded(), false);
+    this._audioHandlers = {
+      pause: () => {
+        if (this.state === 'playing') {
+          this.pausePlayback();
+        }
+      },
+      play: () => {
+        // This is here to handle audio triggered start/stop (like headphones
+        // being removed or inserted)
+        if (this.state === 'idle' && this.audioStartedCallback == null) {
+          this.resumePlayback();
+        }
+      },
+      playing: () => this.audioStarted(),
+      ended: () => this.audioEnded(),
+    };
+    this.audio.addEventListener('pause', this._audioHandlers.pause);
+    this.audio.addEventListener('play', this._audioHandlers.play);
+    this.audio.addEventListener('playing', this._audioHandlers.playing, false);
+    this.audio.addEventListener('ended', this._audioHandlers.ended, false);
   }
 
   loadEvents(
@@ -710,7 +757,8 @@ class Recorder {
   startWorker() {
     if (this.worker == null) {
       this.worker = new Worker();
-      this.worker.addEventListener('message', this.parseMessage.bind(this));
+      this._boundParseMessage = this.parseMessage.bind(this);
+      this.worker.addEventListener('message', this._boundParseMessage);
     }
   }
 


### PR DESCRIPTION
## Summary
- Store bound scroll listener reference so `disableScrolling()` actually removes it (was creating a new `.bind()` each call)
- Add `Recorder.cleanup()` to remove audio/worker event listeners and clear pending timers
- Remove HTMLObject DOM elements and free VertexText canvas backing store on cleanup
- Delegate texture deletion to `webgl.deleteTexture()` for complete GL resource cleanup