### PR TITLE
fix: preserve atlasId through FigureFont.definition()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Releases
 
+## 1.1.4
+* Fix `atlasId` not preserved through `FigureFont.definition()`, causing fonts reconstructed from a definition (e.g. equation text elements) to each create a separate WebGL atlas texture instead of sharing one
+
 ## 1.1.3
 * Fix GL buffer leaks on repeated `addElements()` calls by cleaning up existing buffers before overwriting attribute entries and fullLineHeight primitives
 * Fix equation symbol type mismatch when a key maps to a different symbol type on re-add — properly remove the old element instead of reusing the wrong type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/DrawingObjects/TextObject/TextObject.ts
+++ b/src/js/figure/DrawingObjects/TextObject/TextObject.ts
@@ -455,6 +455,7 @@ class FigureFont {
       modifiers: this.modifiers,
       underline: this.underline,
       atlasColor: this.atlasColor,
+      atlasId: this.atlasId,
       atlasSize: this.atlasSize,
       render: this.render,
       letterSpacing: this.letterSpacing,


### PR DESCRIPTION
## Summary
- Add missing `atlasId` property to `FigureFont.definition()` return object
- Without it, fonts reconstructed from a definition (e.g. equation text elements) lose their `atlasId`, causing each font size to create a separate WebGL atlas texture instead of sharing one