### PR TITLE
Add configurable textStyle default for equations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Releases
 
+## 1.1.5
+* Add configurable `textStyle` option to Figure, FigurePrimitives, and Equation, allowing the default equation text style to be set to `'normal'` instead of the default `'italic'`
+
 ## 1.1.4
 * Fix `atlasId` not preserved through `FigureFont.definition()`, causing fonts reconstructed from a definition (e.g. equation text elements) to each create a separate WebGL atlas texture instead of sharing one
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/Equation/Equation.ts
+++ b/src/js/figure/Equation/Equation.ts
@@ -735,6 +735,7 @@ export type EQN_Equation = {
   dimColor?: TypeColor;
   font?: OBJ_Font;
   textFont?: OBJ_Font;
+  textStyle?: 'italic' | 'normal';
   scale?: number;
   elements?: EQN_EquationElements;
   formDefaults: EQN_FormDefaults;
@@ -1129,15 +1130,16 @@ export class Equation extends FigureElementCollection {
     } else {
       optionsToUse.font = new FigureFont(defaultFont as any);
     }
+    const defaultTextStyle = options.textStyle || shapes.defaultTextStyle || 'italic';
     if (options.textFont instanceof FigureFont) {
       optionsToUse.textFont = options.textFont;
     } else if (options.textFont != null) {
       optionsToUse.textFont = new FigureFont(
-        joinObjects<any>({}, optionsToUse.font, { style: 'italic' }, options.textFont),
+        joinObjects<any>({}, optionsToUse.font, { style: defaultTextStyle }, options.textFont),
       );
     } else {
       optionsToUse.textFont = new FigureFont(
-        joinObjects<any>({}, optionsToUse.font, { style: 'italic' }),
+        joinObjects<any>({}, optionsToUse.font, { style: defaultTextStyle }),
       );
     }
     if (optionsToUse.transform != null) {

--- a/src/js/figure/Figure.ts
+++ b/src/js/figure/Figure.ts
@@ -115,6 +115,7 @@ export type OBJ_Figure = {
   scene?: OBJ_Scene | TypeParsableRect;
   color?: TypeColor;
   font?: OBJ_Font;
+  textStyle?: 'italic' | 'normal';
   lineWidth?: number;
   length?: number;
   backgroundColor?: number;
@@ -309,6 +310,7 @@ class Figure {
   defaultColor!: Array<number>;
   defaultDimColor!: Array<number>;
   defaultFont!: OBJ_Font;
+  defaultTextStyle!: 'italic' | 'normal';
   defaultLineWidth!: number;
   defaultLength!: number;
 
@@ -448,6 +450,7 @@ class Figure {
     }
     this.defaultDimColor = optionsToUse.dimColor;
     this.defaultFont = optionsToUse.font;
+    this.defaultTextStyle = optionsToUse.textStyle || 'italic';
     this.htmlId = htmlId;
     this.animationFinishedCallback = null;
     if (FIGURE1DEBUG) {
@@ -1420,6 +1423,7 @@ class Figure {
       this.defaultColor,
       this.defaultDimColor,
       this.defaultFont,
+      this.defaultTextStyle,
       this.defaultLineWidth,
       this.defaultLength,
       this.timeKeeper,

--- a/src/js/figure/FigurePrimitives/FigurePrimitives.ts
+++ b/src/js/figure/FigurePrimitives/FigurePrimitives.ts
@@ -188,6 +188,7 @@ export default class FigurePrimitives {
   defaultColor: Array<number>;
   defaultDimColor: Array<number>;
   defaultFont: OBJ_Font;
+  defaultTextStyle: 'italic' | 'normal';
   defaultLineWidth: number;
   defaultLength: number;
   timeKeeper: TimeKeeper;
@@ -209,6 +210,7 @@ export default class FigurePrimitives {
     defaultColor: Array<number>,
     defaultDimColor: Array<number>,
     defaultFont: OBJ_Font,
+    defaultTextStyle: 'italic' | 'normal',
     defaultLineWidth: number,
     defaultLength: number,
     timeKeeper: TimeKeeper,
@@ -236,6 +238,7 @@ export default class FigurePrimitives {
     this.defaultColor = defaultColor;
     this.defaultDimColor = defaultDimColor;
     this.defaultFont = defaultFont;
+    this.defaultTextStyle = defaultTextStyle;
     this.defaultLineWidth = defaultLineWidth;
     this.defaultLength = defaultLength;
     this.timeKeeper = timeKeeper;


### PR DESCRIPTION
## Summary
- Add `textStyle` option to Figure, FigurePrimitives, and Equation allowing the default equation text style to be set to `'normal'` instead of `'italic'`
- Release v1.1.5