### PR TITLE
Gracefully handle WebGL context unavailability

### DIFF
--- a/docs/DETAILED_CHANGELOG.md
+++ b/docs/DETAILED_CHANGELOG.md
@@ -1,0 +1,39 @@
+# Detailed Changelog
+
+## 2026-04-20 — Graceful WebGL unavailability
+
+**Why this exists**
+
+On resource-constrained hardware (or when too many WebGL contexts are already in use on a page), the browser can refuse to give FigureOne a WebGL context. Previously this threw during `new Figure(...)` and broke the surrounding app. It could also crash later if the browser *lost* an active context and your code kept adding elements or drawing in the meantime — common in React reloads or tab-switching scenarios.
+
+Figures now tolerate all three states: **never got a context**, **context lost mid-run**, and **context restored**. The figure stays constructible and usable; rendering silently no-ops while unavailable and resumes when a context is available.
+
+**What you can use**
+
+1. **Construction-time callback** — pass `onWebGLUnavailable` to the `Figure` options. Fires once if the browser refuses the initial context.
+   ```js
+   new Fig.Figure({
+     scene: [-1, -1, 1, 1],
+     onWebGLUnavailable: () => showFallbackUI(),
+   });
+   ```
+
+2. **`figure.webglAvailable`** — boolean getter. `true` when a live context is attached, `false` otherwise. Reflects the initial-unavailable state *and* runtime context loss/restore. Safe to read at any time.
+
+3. **`contextLost` / `contextRestored` notifications** — subscribe via the existing notifications system for runtime transitions:
+   ```js
+   figure.notifications.add('contextLost', () => { /* pause UI, show banner */ });
+   figure.notifications.add('contextRestored', () => { /* resume */ });
+   ```
+
+**What you don't need to do**
+
+- No guards around `figure.add(...)` while the context is lost — elements can be added and will render once the context returns.
+- No guards around the draw loop — draws during loss are no-ops.
+- No changes to existing Figure code. These are purely additive; ignoring them keeps old behaviour (minus the crash).
+
+**Recommended integration**
+
+- If you have a fallback UI, wire `onWebGLUnavailable` to show it.
+- If you care about runtime loss (long-running dashboards, tab-switching), subscribe to `contextLost` / `contextRestored` to pause/resume app logic that assumes frames are rendering.
+- For anything else, no action needed — the crash is just gone.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 1.2.0
+* Tolerate WebGL context unavailability: `Figure` construction no longer throws when the browser cannot provide a context, and adding elements / drawing during runtime context loss is safe
+* Add `onWebGLUnavailable` Figure option, fired once during construction if no context is available
+* Add `figure.webglAvailable` getter and document the existing `contextLost` / `contextRestored` notifications for runtime context transitions
+
 ## 1.1.6
 * Add inline element creation in equation forms using `{ make, name, ... }` syntax, supporting any element type (text, polygon, etc.) directly in form definitions
 * Fix TypeDoc generation in Docker by adding missing `typedoc.json` and `typedoc-strip-prefix.cjs` volume mounts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/Figure.ts
+++ b/src/js/figure/Figure.ts
@@ -107,6 +107,11 @@ export type OBJ_FigureForElement = {
   * @property {boolean} [antialias] enable WebGL anti-aliasing (`true`)
   * @property {number} [atlasScale] scale factor for GL text atlas texture
   * resolution relative to 1:1 pixel mapping (`2`)
+ * @property {() => void} [onWebGLUnavailable] callback fired once during
+ * construction if the browser cannot provide a WebGL context (e.g. context
+ * limit reached on resource-constrained hardware). The figure will still be
+ * created but nothing will render. For runtime context loss, subscribe to
+ * the `contextLost` / `contextRestored` notifications instead.
  * @interface
  * @group Figure
  */
@@ -121,6 +126,7 @@ export type OBJ_Figure = {
   backgroundColor?: number;
   antialias?: boolean;
   atlasScale?: number;
+  onWebGLUnavailable?: () => void;
 };
 
 
@@ -194,6 +200,8 @@ export type OBJ_Figure = {
  * - `beforeDraw`: published before a frame is drawn
  * - `afterDraw`: published after a frame is drawn
  * - `resize`: published after a resize event, but before frame drawing
+ * - `contextLost`: published when the browser removes the WebGL context
+ * - `contextRestored`: published when the browser returns the WebGL context
  *
  * @class
  * @param {OBJ_Figure} options
@@ -204,6 +212,10 @@ export type OBJ_Figure = {
  * @property {NotificationManager} notifications notification manager for
  * element
  * @property {FontManager} fonts watches and reports on font availability
+ * @property {boolean} webglAvailable `true` when a live WebGL context is
+ * attached to the figure. `false` if the browser could not provide a
+ * context at construction time or if the context has since been lost (see
+ * the `contextLost` / `contextRestored` notifications)
  *
  * @example
  * // Simple html and javascript example to create a figure, and add a
@@ -374,6 +386,15 @@ class Figure {
 
   scene!: Scene;
   fonts!: FontManager;
+
+  /**
+   * `true` when a live WebGL context is attached to the figure. `false` if
+   * the browser could not provide a context at construction time, or if the
+   * context has since been lost. Transitions back to `true` when the
+   * context is restored. Subscribe to the `contextLost` and
+   * `contextRestored` notifications to react to runtime transitions.
+   */
+  get webglAvailable(): boolean { return this.webglLow.webglAvailable; }
 
   animations!: AnimationManager;
 
@@ -552,6 +573,9 @@ class Figure {
           optionsToUse.atlasScale,
         );
         this.webglLow = webglLow;
+        if (!webglLow.webglAvailable && optionsToUse.onWebGLUnavailable) {
+          optionsToUse.onWebGLUnavailable();
+        }
         this._boundContextLost = this.contextLost.bind(this) as EventListener;
         this._boundContextRestored = this.contextRestored.bind(this) as EventListener;
         this.canvasLow.addEventListener(
@@ -1485,6 +1509,7 @@ class Figure {
     event.preventDefault();
     this.lostContextMessage.innerHTML = '<div class="figureone__lostcontext_message"><p>Browser removed WebGL context from FigureOne and has yet to return it.</p> <p>Reload page to restore.</p></div>';
     this.lostContextMessage.style.display = 'table';
+    this.webglLow.webglAvailable = false;
     this.elements.contextLost();
     this.webglLow.contextLost();
     this.notifications.publish('contextLost');
@@ -1496,6 +1521,7 @@ class Figure {
     this.webglLow.init(this.webglLow.gl);
     this.webglLow.recreateAtlases();
     this.init(this.webglLow);
+    this.webglLow.webglAvailable = true;
     this.lostContextMessage.style.display = 'none';
     this.notifications.publish('contextRestored');
     Console('FigureOne context restored!');

--- a/src/js/figure/tests/Figure/context.test.ts
+++ b/src/js/figure/tests/Figure/context.test.ts
@@ -126,6 +126,26 @@ describe('Figure context loss', () => {
     expect(order).toEqual(['lost', 'restored']);
   });
 
+  test('figure.webglAvailable reflects webglLow.webglAvailable', () => {
+    figure.webglLow.webglAvailable = true;
+    expect(figure.webglAvailable).toBe(true);
+    figure.webglLow.webglAvailable = false;
+    expect(figure.webglAvailable).toBe(false);
+  });
+
+  test('webglAvailable is false after contextLost', () => {
+    figure.webglLow.webglAvailable = true;
+    figure.contextLost({ preventDefault: () => {} });
+    expect(figure.webglAvailable).toBe(false);
+  });
+
+  test('webglAvailable is true after contextRestored', () => {
+    figure.contextLost({ preventDefault: () => {} });
+    expect(figure.webglAvailable).toBe(false);
+    figure.contextRestored();
+    expect(figure.webglAvailable).toBe(true);
+  });
+
   test('adding multiple element types during context loss does not crash', () => {
     // Simulate context loss
     figure.webglLow.getProgram = () => -1;

--- a/src/js/figure/webgl/webgl.context.test.ts
+++ b/src/js/figure/webgl/webgl.context.test.ts
@@ -166,6 +166,12 @@ describe('WebGL context loss handling', () => {
     document.createElement = origCreateElement;
   });
 
+  describe('webglAvailable flag', () => {
+    test('is true when a real gl context is provided', () => {
+      expect(webgl.webglAvailable).toBe(true);
+    });
+  });
+
   describe('getProgram with working context', () => {
     test('creates a program and returns a valid index', () => {
       const index = webgl.getProgram('simple', 'simple');
@@ -406,5 +412,155 @@ describe('Figure atlas integration', () => {
     ]);
 
     expect(Object.keys(figure.webglLow.atlases)).toHaveLength(2);
+  });
+});
+
+describe('WebGLInstance with null gl (glMock fallback)', () => {
+  let origCreateElement;
+
+  beforeEach(() => {
+    FontManager.instance = undefined;
+    origCreateElement = document.createElement.bind(document);
+    document.createElement = (name) => {
+      const el = origCreateElement(name);
+      if (name === 'canvas') {
+        el.getContext = (type) => {
+          if (type === '2d') {
+            return {
+              canvas: el,
+              measureText: () => ({ width: 10 }),
+              fillText: () => {},
+              strokeText: () => {},
+              clearRect: () => {},
+              fillRect: () => {},
+              beginPath: () => {},
+              rect: () => {},
+              stroke: () => {},
+              fillStyle: '',
+              strokeStyle: '',
+              font: '',
+              lineWidth: 1,
+            };
+          }
+          return null;
+        };
+      }
+      return el;
+    };
+  });
+
+  afterEach(() => {
+    document.createElement = origCreateElement;
+  });
+
+  const nullCanvas = () => ({
+    width: 100,
+    clientWidth: 100,
+    height: 100,
+    clientHeight: 100,
+    style: { top: 0, visibility: 'visible' },
+    getContext: () => null,
+  });
+
+  test('constructor does not throw when getContext returns null', () => {
+    expect(() => new WebGLInstance(nullCanvas() as any, [1, 1, 1, 1])).not.toThrow();
+  });
+
+  test('webglAvailable is false when getContext returns null', () => {
+    const instance = new WebGLInstance(nullCanvas() as any, [1, 1, 1, 1]);
+    expect(instance.webglAvailable).toBe(false);
+  });
+
+  test('init still creates a targetTexture under the mock', () => {
+    const instance = new WebGLInstance(nullCanvas() as any, [1, 1, 1, 1]);
+    expect(instance.targetTexture).not.toBeNull();
+  });
+});
+
+describe('Figure onWebGLUnavailable callback', () => {
+  let origCreateElement;
+
+  const setupDom = (webglReturns: 'gl' | 'null', gl: any) => {
+    document.body.innerHTML =
+      '<div id="c">'
+      + '  <canvas class="figureone__gl" id="id_figureone__gl__low">'
+      + '  </canvas>'
+      + '  <canvas class="figureone__text" id="id_figureone__text__low">'
+      + '  </canvas>'
+      + '  <div class="figureone__html">'
+      + '  </div>'
+      + '</div>';
+
+    const make2DStub = (canvas: any) => ({
+      canvas,
+      measureText: () => ({ width: 10 }),
+      fillText: () => {},
+      strokeText: () => {},
+      clearRect: () => {},
+      fillRect: () => {},
+      beginPath: () => {},
+      rect: () => {},
+      stroke: () => {},
+      fillStyle: '',
+      strokeStyle: '',
+      font: '',
+      lineWidth: 1,
+    });
+
+    origCreateElement = document.createElement.bind(document);
+    document.createElement = (name) => {
+      const el = origCreateElement(name);
+      if (name === 'canvas') {
+        el.getContext = (type) => {
+          if (type === '2d') return make2DStub(el);
+          return webglReturns === 'gl' ? gl : null;
+        };
+      }
+      return el;
+    };
+
+    document.querySelectorAll('canvas').forEach((canvas: any) => {
+      // eslint-disable-next-line no-param-reassign
+      canvas.getContext = (type: string) => {
+        if (type === '2d') return make2DStub(canvas);
+        return webglReturns === 'gl' ? gl : null;
+      };
+    });
+  };
+
+  beforeEach(() => {
+    FontManager.instance = undefined;
+  });
+
+  afterEach(() => {
+    document.createElement = origCreateElement;
+  });
+
+  test('fires once when getContext returns null', () => {
+    setupDom('null', null);
+    const onWebGLUnavailable = jest.fn();
+    // eslint-disable-next-line no-new
+    new Figure({ htmlId: 'c', color: [1, 0, 0, 1], onWebGLUnavailable });
+    expect(onWebGLUnavailable).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fire when a real gl context is available', () => {
+    setupDom('gl', createMockGL());
+    const onWebGLUnavailable = jest.fn();
+    // eslint-disable-next-line no-new
+    new Figure({ htmlId: 'c', color: [1, 0, 0, 1], onWebGLUnavailable });
+    expect(onWebGLUnavailable).not.toHaveBeenCalled();
+  });
+
+  test('figure.webglAvailable is false when getContext returns null', () => {
+    setupDom('null', null);
+    const figure = new Figure({ htmlId: 'c', color: [1, 0, 0, 1] });
+    expect(figure.webglAvailable).toBe(false);
+  });
+
+  test('figure.webglAvailable is true when gl is available', () => {
+    setupDom('gl', createMockGL());
+    const figure = new Figure({ htmlId: 'c', color: [1, 0, 0, 1] });
+    expect(figure.webglAvailable).toBe(true);
   });
 });

--- a/src/js/figure/webgl/webgl.context.test.ts
+++ b/src/js/figure/webgl/webgl.context.test.ts
@@ -463,16 +463,16 @@ describe('WebGLInstance with null gl (glMock fallback)', () => {
   });
 
   test('constructor does not throw when getContext returns null', () => {
-    expect(() => new WebGLInstance(nullCanvas() as any, [1, 1, 1, 1])).not.toThrow();
+    expect(() => new WebGLInstance(nullCanvas(), [1, 1, 1, 1])).not.toThrow();
   });
 
   test('webglAvailable is false when getContext returns null', () => {
-    const instance = new WebGLInstance(nullCanvas() as any, [1, 1, 1, 1]);
+    const instance = new WebGLInstance(nullCanvas(), [1, 1, 1, 1]);
     expect(instance.webglAvailable).toBe(false);
   });
 
   test('init still creates a targetTexture under the mock', () => {
-    const instance = new WebGLInstance(nullCanvas() as any, [1, 1, 1, 1]);
+    const instance = new WebGLInstance(nullCanvas(), [1, 1, 1, 1]);
     expect(instance.targetTexture).not.toBeNull();
   });
 });
@@ -480,7 +480,7 @@ describe('WebGLInstance with null gl (glMock fallback)', () => {
 describe('Figure onWebGLUnavailable callback', () => {
   let origCreateElement;
 
-  const setupDom = (webglReturns: 'gl' | 'null', gl: any) => {
+  const setupDom = (webglReturns, gl) => {
     document.body.innerHTML =
       '<div id="c">'
       + '  <canvas class="figureone__gl" id="id_figureone__gl__low">'
@@ -491,7 +491,7 @@ describe('Figure onWebGLUnavailable callback', () => {
       + '  </div>'
       + '</div>';
 
-    const make2DStub = (canvas: any) => ({
+    const make2DStub = canvas => ({
       canvas,
       measureText: () => ({ width: 10 }),
       fillText: () => {},
@@ -519,9 +519,9 @@ describe('Figure onWebGLUnavailable callback', () => {
       return el;
     };
 
-    document.querySelectorAll('canvas').forEach((canvas: any) => {
+    document.querySelectorAll('canvas').forEach((canvas) => {
       // eslint-disable-next-line no-param-reassign
-      canvas.getContext = (type: string) => {
+      canvas.getContext = (type) => {
         if (type === '2d') return make2DStub(canvas);
         return webglReturns === 'gl' ? gl : null;
       };

--- a/src/js/figure/webgl/webgl.ts
+++ b/src/js/figure/webgl/webgl.ts
@@ -11,6 +11,7 @@ import type { TypeColor } from '../../tools/types';
 import type { OBJ_Atlas } from './Atlas';
 
 const glMock = {
+  // Constants
   TRIANGLES: 1,
   TRIANGLE_STRIP: 2,
   TRIANGLE_FAN: 3,
@@ -21,8 +22,10 @@ const glMock = {
   FRAGMENT_SHADER: 1,
   SRC_ALPHA: 1,
   ONE_MINUS_SRC_ALPHA: 1,
+  ONE: 1,
   BLEND: 1,
   COLOR_BUFFER_BIT: 1,
+  DEPTH_TEST: 1,
   TEXTURE_2D: 1,
   RGBA: 1,
   UNSIGNED_BYTE: 1,
@@ -35,6 +38,16 @@ const glMock = {
   STATIC_DRAW: 1,
   FLOAT: 1,
   UNPACK_PREMULTIPLY_ALPHA_WEBGL: 1,
+  UNPACK_FLIP_Y_WEBGL: 1,
+  REPEAT: 1,
+  TEXTURE0: 1,
+  RENDERBUFFER: 1,
+  FRAMEBUFFER: 1,
+  COLOR_ATTACHMENT0: 1,
+  DEPTH_ATTACHMENT: 1,
+  DEPTH_COMPONENT16: 1,
+
+  // Methods
   createBuffer: () => {},
   bindBuffer: () => {},
   bufferData: () => {},
@@ -49,7 +62,7 @@ const glMock = {
   drawArrays: () => {},
   clearColor: () => {},
   clear: () => {},
-  createTexture: () => {},
+  createTexture: () => null,
   activeTexture: () => {},
   bindTexture: () => {},
   pixelStorei: () => {},
@@ -75,6 +88,23 @@ const glMock = {
   deleteShader: () => {},
   useProgram: () => {},
   viewport: () => {},
+  generateMipmap: () => {},
+  deleteTexture: () => {},
+  getProgramInfoLog: () => '',
+
+  // Framebuffer/renderbuffer methods (used by TargetTexture)
+  createRenderbuffer: () => null,
+  bindRenderbuffer: () => {},
+  renderbufferStorage: () => {},
+  createFramebuffer: () => null,
+  bindFramebuffer: () => {},
+  framebufferTexture2D: () => {},
+  framebufferRenderbuffer: () => {},
+  deleteRenderbuffer: () => {},
+  deleteFramebuffer: () => {},
+
+  drawingBufferWidth: 100,
+  drawingBufferHeight: 100,
   canvas: ({
     toDataURL: () => '',
     width: 100,
@@ -557,6 +587,7 @@ class WebGLInstance {
   }
 
   atlasScale: number;
+  webglAvailable: boolean;
 
   constructor(
   canvas: HTMLCanvasElement,
@@ -578,10 +609,11 @@ class WebGLInstance {
     this.atlases = {};
     if (gl == null) {
       gl = glMock as any;
+      this.webglAvailable = false;
+    } else {
+      this.webglAvailable = true;
     }
-    if (gl != null) {
-      this.init(gl);
-    }
+    this.init(gl!);
   }
 
   init(gl: WebGLRenderingContext) {


### PR DESCRIPTION
## Summary
- Allow `Figure` construction to succeed when the browser cannot provide a WebGL context, instead of throwing
- Add `onWebGLUnavailable` option and `figure.webglAvailable` getter so apps can detect and fall back
- Keep `figure.add(...)` and the draw loop safe across runtime context loss/restore; document the existing `contextLost` / `contextRestored` notifications