### PR TITLE
Add name to equation functions and Equation.getElementsInForm

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 1.4.0
+* Add optional `name` property to every equation function (container, frac, matrix, brac, annotate, etc.) — purely a label with no layout effect
+* Add `Equation.getElementsInForm(formName, name, mode?, includeHidden?)` to look up the `FigureElement`s inside a named function's sub-tree, with `mode: 'first'` returning the first match and `mode: 'all'` returning the de-duplicated union across all matches (including names nested inside annotations)
+
 ## 1.3.0
 * Add `isFormIgnored` flag on `FigureElement` to exclude an element from equation form changes — when set, the element is skipped by form layout, show/hide, transform/color sets, and `elementMods`, so its user-applied transform, color, and visibility persist across `showForm` / `goToForm`
 * Form-ignored elements contribute zero size to layout, so they don't shift adjacent elements when included in a form's content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/Equation/Elements/BaseAnnotationFunction.ts
+++ b/src/js/figure/Equation/Elements/BaseAnnotationFunction.ts
@@ -251,6 +251,10 @@ export default class BaseAnnotationFunction implements ElementInterface {
   annotations: Array<EQN_Annotation>;
   glyphs: EQN_Glyphs;
   options: Record<string, any>;
+  // Optional caller-supplied identifier, assigned post-dispatch by
+  // EquationFunctions.eqnMethod. Has no layout effect; used by
+  // Equation.getElementsInForm to look up the contents of a sub-tree.
+  functionName: string | null;
 
   constructor(
     content: ElementInterface,
@@ -267,6 +271,7 @@ export default class BaseAnnotationFunction implements ElementInterface {
     this.showContent = showContent;
     this.scale = 1;
     this.color = null;
+    this.functionName = null;
   }
 
   _dup(namedCollection?: Record<string, any>) {

--- a/src/js/figure/Equation/Elements/BaseEquationFunction.ts
+++ b/src/js/figure/Equation/Elements/BaseEquationFunction.ts
@@ -14,6 +14,10 @@ export default class BaseEquationFunction extends Elements {
   glyphHeights: Array<number>;
   override showContent: boolean;
   options: Record<string, any>;
+  // Optional caller-supplied identifier, assigned post-dispatch by
+  // EquationFunctions.eqnMethod. Has no layout effect; used by
+  // Equation.getElementsInForm to look up the contents of a sub-tree.
+  functionName: string | null;
 
   constructor(
     content: Elements | null | Array<Elements | null>,
@@ -51,6 +55,7 @@ export default class BaseEquationFunction extends Elements {
     this.glyphHeights = glyphElements.map(() => 1);
     this.options = options;
     this.showContent = showContent;
+    this.functionName = null;
   }
 
   override _dup(namedCollection?: Record<string, any>) {

--- a/src/js/figure/Equation/Equation.ts
+++ b/src/js/figure/Equation/Equation.ts
@@ -12,6 +12,7 @@ import {
 import type { ElementInterface } from './Elements/Element';
 import { Elements } from './Elements/Element';
 import BaseAnnotationFunction from './Elements/BaseAnnotationFunction';
+import BaseEquationFunction from './Elements/BaseEquationFunction';
 import EquationForm from './EquationForm';
 import type {
   TypeHAlign, TypeVAlign,
@@ -2032,6 +2033,91 @@ export class Equation extends FigureElementCollection {
       return [];
     }
     return this.eqn.forms[form].content[0].getAllElements(includeHidden);
+  }
+
+  /**
+   * Return all the elements inside the named equation function within a given
+   * form.
+   *
+   * Any equation function (container, fraction, matrix, etc.) can be tagged
+   * with a `name` property in its options — this has no layout effect, but
+   * makes the function's sub-tree addressable here.
+   *
+   * With `mode: 'first'` (default), returns the elements inside the first
+   * matching function found by a depth-first traversal. With `mode: 'all'`,
+   * walks the entire tree, collects every matching function (including those
+   * nested inside other matches), and returns the de-duplicated union of
+   * their elements.
+   *
+   * Returns an empty array if the form does not exist, or no matching
+   * function is found.
+   *
+   * @param {string} formName
+   * @param {string} name
+   * @param {'first' | 'all'} [mode] (`'first'`)
+   * @param {boolean} [includeHidden] (`false`)
+   * @return {Array<FigureElement>}
+   */
+  getElementsInForm(
+    formName: string,
+    name: string,
+    mode: 'first' | 'all' = 'first',
+    includeHidden: boolean = false,
+  ) {
+    const form = this.eqn.forms[formName];
+    if (form == null) {
+      return [];
+    }
+    // Single typed accessor that hides the structural differences between
+    // Elements (.content: ElementInterface[]) and BaseAnnotationFunction
+    // (.content: ElementInterface + .annotations[].content). All `as any`
+    // casts for this walk live here.
+    const childrenOf = (node: ElementInterface): Array<ElementInterface> => {
+      const out: Array<ElementInterface> = [];
+      const c = (node as any).content;
+      if (Array.isArray(c)) {
+        out.push(...c);
+      } else if (c != null) {
+        out.push(c);
+      }
+      const annotations = (node as any).annotations;
+      if (Array.isArray(annotations)) {
+        annotations.forEach((a: any) => {
+          if (a != null && a.content != null) out.push(a.content);
+        });
+      }
+      return out;
+    };
+    const matches: Array<BaseEquationFunction | BaseAnnotationFunction> = [];
+    const walk = (nodes: Array<ElementInterface>): boolean => {
+      for (let i = 0; i < nodes.length; i += 1) {
+        const node = nodes[i];
+        if (
+          (node instanceof BaseEquationFunction || node instanceof BaseAnnotationFunction)
+          && node.functionName === name
+        ) {
+          matches.push(node);
+          if (mode === 'first') return true;
+        }
+        if (walk(childrenOf(node))) return true;
+      }
+      return false;
+    };
+    walk(form.content);
+    if (matches.length === 0) {
+      return [];
+    }
+    const seen = new Set<any>();
+    const out: Array<any> = [];
+    matches.forEach((m) => {
+      m.getAllElements(includeHidden).forEach((el) => {
+        if (!seen.has(el)) {
+          seen.add(el);
+          out.push(el);
+        }
+      });
+    });
+    return out;
   }
 
   /**

--- a/src/js/figure/Equation/EquationFunctions.ts
+++ b/src/js/figure/Equation/EquationFunctions.ts
@@ -18,6 +18,7 @@ import Lines from './Elements/Lines';
 import Scale from './Elements/Scale';
 import Container from './Elements/Container';
 import BaseAnnotationFunction from './Elements/BaseAnnotationFunction';
+import BaseEquationFunction from './Elements/BaseEquationFunction';
 import EquationLine from './Symbols/Line';
 import Offset from './Elements/Offset';
 import Color from './Elements/Color';
@@ -186,6 +187,9 @@ export type TypeEquationPhrase =
  * @property {boolean} [fullContentBounds] - (`false`)
  * @property {boolean} [showContent] - if `false`, a container will be created
  * around the content, but the content will not be shown (`true`)
+ * @property {string} [name] - optional identifier (available on every equation
+ * function). Has no effect on layout, but allows the function's contents to be
+ * looked up later with {@link Equation.getElementsInForm} (`null`)
  *
  * @see To test examples, append them to the
  * <a href="#drawing-boilerplate">boilerplate</a>
@@ -252,6 +256,7 @@ export type EQN_Container = {
   scale?: number,
   fullContentBounds?: boolean,
   showContent?: boolean,
+  name?: string,
 } | [
   TypeEquationPhrase,
   (number | null | undefined),
@@ -305,6 +310,7 @@ export type EQN_Offset = {
   offset?: TypeParsablePoint,
   inSize?: boolean;
   fullContentBounds?: boolean,
+  name?: string,
 } | [
   TypeEquationPhrase,
   (TypeParsablePoint | null | undefined),
@@ -429,6 +435,7 @@ export type EQN_Fraction = {
   offsetY?: number;
   baseline?: 'numerator' | 'denominator' | 'vinculum',
   fullContentBounds?: boolean,
+  name?: string,
 } | [
   TypeEquationPhrase,
   string,
@@ -505,6 +512,7 @@ export type EQN_Scale = {
   content: TypeEquationPhrase,
   scale?: number,
   fullContentBounds?: boolean;
+  name?: string,
 } | [
   TypeEquationPhrase,
   (number | null | undefined),
@@ -584,6 +592,7 @@ export type EQN_Color = {
   content: TypeEquationPhrase,
   color: TypeColor,
   fullContentBounds?: boolean;
+  name?: string,
 } | [
   TypeEquationPhrase,
   TypeColor,
@@ -699,6 +708,7 @@ export type EQN_Bracket = {
   descent?: number;
   fullContentBounds?: boolean;
   useFullBounds?: boolean;
+  name?: string;
 } | [
   string,
   TypeEquationPhrase,
@@ -836,6 +846,7 @@ export type EQN_Root = {
   rootScale?: number,
   fullContentBounds?: boolean,
   useFullBounds?: boolean,
+  name?: string,
 } | [
   string,
   TypeEquationPhrase,
@@ -953,6 +964,7 @@ export type EQN_Strike = {
   leftSpace?: number;
   fullContentBounds?: boolean;
   useFullBounds?: boolean;
+  name?: string;
 } | [
   TypeEquationPhrase,
   string,
@@ -1071,6 +1083,7 @@ export type EQN_Box = {
   leftSpace?: number,
   fullContentBounds?: boolean,
   useFullBounds?: boolean,
+  name?: string,
 } | [
   TypeEquationPhrase,
   string,
@@ -1120,6 +1133,7 @@ export type EQN_TouchBox = {
   rightSpace?: number,
   bottomSpace?: number,
   leftSpace?: number,
+  name?: string,
 } | [
   TypeEquationPhrase,
   string,
@@ -1261,6 +1275,7 @@ export type EQN_Bar = {
   descent?: number,
   fullContentBounds?: boolean,
   useFullBounds?: boolean,
+  name?: string,
 } | [
   TypeEquationPhrase,
   (string | null | undefined),
@@ -1434,6 +1449,7 @@ export type EQN_Integral = {
   toYAlign?: 'bottom' | 'top' | 'middle' | 'baseline' | number,
   fullBoundsContent?: boolean,
   useFullBounds?: boolean,
+  name?: string,
   } | [
   (string | null | undefined),
   (TypeEquationPhrase | null | undefined),
@@ -1575,6 +1591,7 @@ export type EQN_SumOf = {
   toOffset?: TypeParsablePoint,
   fullBoundsContent?: boolean,
   useFullBounds?: boolean,
+  name?: string,
 } | [
   (string | null | undefined),
   TypeEquationPhrase,
@@ -1708,6 +1725,7 @@ export type EQN_ProdOf = {
   toOffset?: TypeParsablePoint,
   fullBoundsContent?: boolean,
   useFullBounds?: boolean,
+  name?: string,
 } | [
   (string | null | undefined),
   TypeEquationPhrase,
@@ -1798,6 +1816,7 @@ export type EQN_Subscript = {
   scale?: number,
   offset?: TypeParsablePoint,
   inSize: boolean,
+  name?: string,
 } | [
   TypeEquationPhrase,
   TypeEquationPhrase,
@@ -1866,6 +1885,7 @@ export type EQN_Superscript = {
   scale?: number,
   offset?: TypeParsablePoint,
   inSize: boolean,
+  name?: string,
 } | [
   TypeEquationPhrase,
   TypeEquationPhrase,
@@ -1936,6 +1956,7 @@ export type EQN_SuperscriptSubscript = {
   superscriptOffset?: TypeParsablePoint;
   subscriptOffset?: TypeParsablePoint;
   inSize?: boolean,
+  name?: string,
 } | [
   TypeEquationPhrase,
   TypeEquationPhrase,
@@ -2049,6 +2070,7 @@ export type EQN_Comment = {
   inSize?: boolean;
   fullContentBounds?: boolean;
   useFullBounds?: boolean;
+  name?: string;
 } | [
   TypeEquationPhrase,
   TypeEquationPhrase,
@@ -2146,6 +2168,7 @@ export type EQN_StrikeComment = {
   space?: number,
   scale?: number,
   commentSpace?: number,
+  name?: string,
 } | [
   (TypeEquationPhrase | null | undefined),
   (string | null | undefined),
@@ -2224,6 +2247,7 @@ export type EQN_Pad = {
   right?: number,
   bottom?: number,
   left?: number,
+  name?: string,
 } | [
   TypeEquationPhrase,
   (number | null | undefined),
@@ -2347,6 +2371,7 @@ export type EQN_Matrix = {
   yAlign?: 'baseline' | 'middle',
   brac?: EQN_Bracket,
   fullContentBounds?: boolean,
+  name?: string,
 } | [
   ([number, number] | null | undefined),
   (string | null | undefined),
@@ -2504,6 +2529,7 @@ export type EQN_Lines = {
   space?: number,
   yAlign?: 'bottom' | 'top' | 'middle' | number,
   fullContentBounds?: boolean,
+  name?: string,
 };
 
 /**
@@ -3267,6 +3293,7 @@ export type EQN_Annotate = {
   leftSpace?: number,
   rightSpace?: number,
   contentScale?: number,
+  name?: string,
 };
 
 // There are lots of FlowFixMes in this file. This is not perfect, but
@@ -3437,6 +3464,24 @@ export class EquationFunctions {
   }
 
   eqnMethod(name: string, params: any) {
+    const result = this.dispatchEqnMethod(name, params);
+    // Allow any equation function to be tagged with a caller-supplied
+    // `name` via its options object. The tag has no layout effect; it's
+    // used by Equation.getElementsInForm to look up the function's sub-tree.
+    if (
+      result != null
+      && params != null
+      && !Array.isArray(params)
+      && typeof params === 'object'
+      && (params as any).name != null
+      && (result instanceof BaseEquationFunction || result instanceof BaseAnnotationFunction)
+    ) {
+      result.functionName = (params as any).name;
+    }
+    return result;
+  }
+
+  dispatchEqnMethod(name: string, params: any) {
     if (name === 'frac') { return this.frac(params); }
     if (name === 'strike') { return this.strike(params); }
     if (name === 'box') { return this.box(params); }

--- a/src/js/figure/Equation/FunctionTests/Equation.container.test.ts
+++ b/src/js/figure/Equation/FunctionTests/Equation.container.test.ts
@@ -348,4 +348,147 @@ describe('Equation Functions - Container', () => {
     expect(round(eqn._b.transform.mat)).toMatchSnapshot();
     expect(round(eqn._c.transform.mat)).toMatchSnapshot();
   });
+  describe('Named equation function', () => {
+    let setup;
+    beforeEach(() => {
+      setup = () => {
+        eqn = new Equation(figure.shapes, { color: color1 });
+        eqn.addElements({
+          a: 'a', b: 'b', c: 'c', d: 'd', v: { symbol: 'vinculum' },
+        });
+        eqn.addForms({
+          named: {
+            content: [
+              'a',
+              { container: { content: ['b', 'c'], name: 'inner' } },
+            ],
+          },
+          baseline: {
+            content: [
+              'a',
+              { container: { content: ['b', 'c'] } },
+            ],
+          },
+          nested: {
+            content: [
+              {
+                container: {
+                  content: [
+                    'a',
+                    { container: { content: ['b', 'c'], name: 'inner' } },
+                  ],
+                  name: 'outer',
+                },
+              },
+            ],
+          },
+          namedFraction: {
+            content: [
+              'a',
+              {
+                frac: {
+                  numerator: 'b', symbol: 'v', denominator: 'c', name: 'ratio',
+                },
+              },
+            ],
+          },
+          twoMatches: {
+            content: [
+              { container: { content: ['a', 'b'], name: 'tag' } },
+              'c',
+              { container: { content: ['b', 'c', 'd'], name: 'tag' } },
+            ],
+          },
+          plain: {
+            content: ['a', 'b', 'c'],
+          },
+        });
+        figure.elements = eqn;
+        figure.setFirstTransform();
+      };
+    });
+    test('name does not affect layout', () => {
+      setup();
+      eqn.showForm('baseline');
+      figure.setFirstTransform();
+      const basePositions = [eqn._a, eqn._b, eqn._c].map(
+        e => round(e.transform.mat).slice(),
+      );
+      eqn.showForm('named');
+      figure.setFirstTransform();
+      const namedPositions = [eqn._a, eqn._b, eqn._c].map(
+        e => round(e.transform.mat).slice(),
+      );
+      expect(namedPositions).toEqual(basePositions);
+    });
+    test('getElementsInForm returns elements inside a named container', () => {
+      setup();
+      const found = eqn.getElementsInForm('named', 'inner');
+      expect(found.map(e => e.name)).toEqual(['b', 'c']);
+    });
+    test('getElementsInForm works for non-container functions (frac)', () => {
+      setup();
+      const found = eqn.getElementsInForm('namedFraction', 'ratio');
+      expect(found.map(e => e.name).sort()).toEqual(['b', 'c', 'v']);
+    });
+    test('getElementsInForm finds nested named functions', () => {
+      setup();
+      const outer = eqn.getElementsInForm('nested', 'outer').map(e => e.name);
+      const inner = eqn.getElementsInForm('nested', 'inner').map(e => e.name);
+      expect(outer).toEqual(['a', 'b', 'c']);
+      expect(inner).toEqual(['b', 'c']);
+    });
+    test('getElementsInForm returns [] when form is missing', () => {
+      setup();
+      expect(eqn.getElementsInForm('missing', 'inner')).toEqual([]);
+    });
+    test('getElementsInForm returns [] when name is not found', () => {
+      setup();
+      expect(eqn.getElementsInForm('named', 'nope')).toEqual([]);
+      expect(eqn.getElementsInForm('plain', 'inner')).toEqual([]);
+    });
+    test('mode "first" returns only the first match', () => {
+      setup();
+      const found = eqn.getElementsInForm('twoMatches', 'tag', 'first');
+      expect(found.map(e => e.name)).toEqual(['a', 'b']);
+    });
+    test('mode "all" aggregates and dedupes across matches', () => {
+      setup();
+      const found = eqn.getElementsInForm('twoMatches', 'tag', 'all');
+      // First tag has [a, b]; second tag has [b, c, d]. `b` overlaps and
+      // must appear only once, in first-seen order.
+      expect(found.map(e => e.name)).toEqual(['a', 'b', 'c', 'd']);
+    });
+    test('mode "all" returns inner-and-outer elements for nested matches', () => {
+      setup();
+      const outerNested = eqn.getElementsInForm('nested', 'outer', 'all');
+      const innerNested = eqn.getElementsInForm('nested', 'inner', 'all');
+      expect(outerNested.map(e => e.name)).toEqual(['a', 'b', 'c']);
+      expect(innerNested.map(e => e.name)).toEqual(['b', 'c']);
+    });
+    test('walker descends into annotate annotations[].content', () => {
+      eqn = new Equation(figure.shapes, { color: color1 });
+      eqn.addElements({
+        a: 'a', b: 'b', c: 'c', d: 'd',
+      });
+      eqn.addForms({
+        ann: {
+          annotate: {
+            content: 'a',
+            annotation: {
+              content: {
+                container: { content: ['b', 'c'], name: 'insideAnnotation' },
+              },
+              yPosition: 'top',
+              yAlign: 'bottom',
+            },
+          },
+        },
+      });
+      figure.elements = eqn;
+      figure.setFirstTransform();
+      const found = eqn.getElementsInForm('ann', 'insideAnnotation');
+      expect(found.map(e => e.name)).toEqual(['b', 'c']);
+    });
+  });
 });

--- a/src/tests/api-examples/index.js
+++ b/src/tests/api-examples/index.js
@@ -72,10 +72,6 @@ figure.add([
 ]);
 
 
-figure.scene.setProjection({ style: 'orthographic' });
-figure.scene.setCamera({ position: [2, 1, 1], up: [0, 1, 0] });
-figure.scene.setLight({ directional: [0.7, 0.5, 1] });
-
 figure.timeKeeper.setManualFrames();
 figure.timeKeeper.frame(0);
 figure.animateNextFrame();


### PR DESCRIPTION
## Summary
- Tag any equation function (container, frac, matrix, annotate, …) with an optional `name` property — no layout effect.
- Add `Equation.getElementsInForm(formName, name, mode?, includeHidden?)` to fetch the FigureElements inside a named function's sub-tree.
- `mode: 'first'` returns the first match; `mode: 'all'` walks the whole form and returns the deduped union, including names nested inside annotations.