### PR TITLE
Rename getElementsInForm to getFunctionElements (breaking vs 1.4.0)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 1.4.1
+* **Breaking (relative to 1.4.0):** rename `Equation.getElementsInForm` → `Equation.getFunctionElements`
+* Reorder parameters to `(name, formName? = null, mode = 'all', includeHidden = false)` — `name` is now first, `formName` defaults to the current form, and `mode` defaults to `'all'`
+
 ## 1.4.0
 * Add optional `name` property to every equation function (container, frac, matrix, brac, annotate, etc.) — purely a label with no layout effect
 * Add `Equation.getElementsInForm(formName, name, mode?, includeHidden?)` to look up the `FigureElement`s inside a named function's sub-tree, with `mode: 'first'` returning the first match and `mode: 'all'` returning the de-duplicated union across all matches (including names nested inside annotations)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/Equation/Elements/BaseAnnotationFunction.ts
+++ b/src/js/figure/Equation/Elements/BaseAnnotationFunction.ts
@@ -253,7 +253,7 @@ export default class BaseAnnotationFunction implements ElementInterface {
   options: Record<string, any>;
   // Optional caller-supplied identifier, assigned post-dispatch by
   // EquationFunctions.eqnMethod. Has no layout effect; used by
-  // Equation.getElementsInForm to look up the contents of a sub-tree.
+  // Equation.getFunctionElements to look up the contents of a sub-tree.
   functionName: string | null;
 
   constructor(

--- a/src/js/figure/Equation/Elements/BaseEquationFunction.ts
+++ b/src/js/figure/Equation/Elements/BaseEquationFunction.ts
@@ -16,7 +16,7 @@ export default class BaseEquationFunction extends Elements {
   options: Record<string, any>;
   // Optional caller-supplied identifier, assigned post-dispatch by
   // EquationFunctions.eqnMethod. Has no layout effect; used by
-  // Equation.getElementsInForm to look up the contents of a sub-tree.
+  // Equation.getFunctionElements to look up the contents of a sub-tree.
   functionName: string | null;
 
   constructor(

--- a/src/js/figure/Equation/Equation.ts
+++ b/src/js/figure/Equation/Equation.ts
@@ -2036,35 +2036,37 @@ export class Equation extends FigureElementCollection {
   }
 
   /**
-   * Return all the elements inside the named equation function within a given
-   * form.
+   * Return all the elements inside the named equation function within a form.
    *
    * Any equation function (container, fraction, matrix, etc.) can be tagged
    * with a `name` property in its options — this has no layout effect, but
    * makes the function's sub-tree addressable here.
    *
-   * With `mode: 'first'` (default), returns the elements inside the first
-   * matching function found by a depth-first traversal. With `mode: 'all'`,
-   * walks the entire tree, collects every matching function (including those
-   * nested inside other matches), and returns the de-duplicated union of
-   * their elements.
+   * With `mode: 'all'` (default), walks the entire tree, collects every
+   * matching function (including those nested inside other matches), and
+   * returns the de-duplicated union of their elements. With `mode: 'first'`,
+   * returns only the elements inside the first matching function found by a
+   * depth-first traversal.
+   *
+   * If `formName` is `null` (default), the current form is used.
    *
    * Returns an empty array if the form does not exist, or no matching
    * function is found.
    *
-   * @param {string} formName
    * @param {string} name
-   * @param {'first' | 'all'} [mode] (`'first'`)
+   * @param {string | null} [formName] (`null` — uses current form)
+   * @param {'first' | 'all'} [mode] (`'all'`)
    * @param {boolean} [includeHidden] (`false`)
    * @return {Array<FigureElement>}
    */
-  getElementsInForm(
-    formName: string,
+  getFunctionElements(
     name: string,
-    mode: 'first' | 'all' = 'first',
+    formName: string | null = null,
+    mode: 'first' | 'all' = 'all',
     includeHidden: boolean = false,
   ) {
-    const form = this.eqn.forms[formName];
+    const resolvedFormName = formName == null ? this.eqn.currentForm : formName;
+    const form = this.eqn.forms[resolvedFormName];
     if (form == null) {
       return [];
     }

--- a/src/js/figure/Equation/EquationFunctions.ts
+++ b/src/js/figure/Equation/EquationFunctions.ts
@@ -189,7 +189,7 @@ export type TypeEquationPhrase =
  * around the content, but the content will not be shown (`true`)
  * @property {string} [name] - optional identifier (available on every equation
  * function). Has no effect on layout, but allows the function's contents to be
- * looked up later with {@link Equation.getElementsInForm} (`null`)
+ * looked up later with {@link Equation.getFunctionElements} (`null`)
  *
  * @see To test examples, append them to the
  * <a href="#drawing-boilerplate">boilerplate</a>
@@ -3467,7 +3467,7 @@ export class EquationFunctions {
     const result = this.dispatchEqnMethod(name, params);
     // Allow any equation function to be tagged with a caller-supplied
     // `name` via its options object. The tag has no layout effect; it's
-    // used by Equation.getElementsInForm to look up the function's sub-tree.
+    // used by Equation.getFunctionElements to look up the function's sub-tree.
     if (
       result != null
       && params != null

--- a/src/js/figure/Equation/FunctionTests/Equation.container.test.ts
+++ b/src/js/figure/Equation/FunctionTests/Equation.container.test.ts
@@ -421,48 +421,55 @@ describe('Equation Functions - Container', () => {
       );
       expect(namedPositions).toEqual(basePositions);
     });
-    test('getElementsInForm returns elements inside a named container', () => {
+    test('getFunctionElements returns elements inside a named container', () => {
       setup();
-      const found = eqn.getElementsInForm('named', 'inner');
+      const found = eqn.getFunctionElements('inner', 'named');
       expect(found.map(e => e.name)).toEqual(['b', 'c']);
     });
-    test('getElementsInForm works for non-container functions (frac)', () => {
+    test('getFunctionElements works for non-container functions (frac)', () => {
       setup();
-      const found = eqn.getElementsInForm('namedFraction', 'ratio');
+      const found = eqn.getFunctionElements('ratio', 'namedFraction');
       expect(found.map(e => e.name).sort()).toEqual(['b', 'c', 'v']);
     });
-    test('getElementsInForm finds nested named functions', () => {
+    test('getFunctionElements finds nested named functions', () => {
       setup();
-      const outer = eqn.getElementsInForm('nested', 'outer').map(e => e.name);
-      const inner = eqn.getElementsInForm('nested', 'inner').map(e => e.name);
+      const outer = eqn.getFunctionElements('outer', 'nested').map(e => e.name);
+      const inner = eqn.getFunctionElements('inner', 'nested').map(e => e.name);
       expect(outer).toEqual(['a', 'b', 'c']);
       expect(inner).toEqual(['b', 'c']);
     });
-    test('getElementsInForm returns [] when form is missing', () => {
+    test('getFunctionElements defaults formName to the current form', () => {
       setup();
-      expect(eqn.getElementsInForm('missing', 'inner')).toEqual([]);
+      eqn.showForm('named');
+      expect(eqn.getFunctionElements('inner').map(e => e.name)).toEqual(['b', 'c']);
+      eqn.showForm('namedFraction');
+      expect(eqn.getFunctionElements('ratio').map(e => e.name).sort()).toEqual(['b', 'c', 'v']);
     });
-    test('getElementsInForm returns [] when name is not found', () => {
+    test('getFunctionElements returns [] when form is missing', () => {
       setup();
-      expect(eqn.getElementsInForm('named', 'nope')).toEqual([]);
-      expect(eqn.getElementsInForm('plain', 'inner')).toEqual([]);
+      expect(eqn.getFunctionElements('inner', 'missing')).toEqual([]);
+    });
+    test('getFunctionElements returns [] when name is not found', () => {
+      setup();
+      expect(eqn.getFunctionElements('nope', 'named')).toEqual([]);
+      expect(eqn.getFunctionElements('inner', 'plain')).toEqual([]);
     });
     test('mode "first" returns only the first match', () => {
       setup();
-      const found = eqn.getElementsInForm('twoMatches', 'tag', 'first');
+      const found = eqn.getFunctionElements('tag', 'twoMatches', 'first');
       expect(found.map(e => e.name)).toEqual(['a', 'b']);
     });
-    test('mode "all" aggregates and dedupes across matches', () => {
+    test('mode "all" (default) aggregates and dedupes across matches', () => {
       setup();
-      const found = eqn.getElementsInForm('twoMatches', 'tag', 'all');
+      const found = eqn.getFunctionElements('tag', 'twoMatches');
       // First tag has [a, b]; second tag has [b, c, d]. `b` overlaps and
       // must appear only once, in first-seen order.
       expect(found.map(e => e.name)).toEqual(['a', 'b', 'c', 'd']);
     });
     test('mode "all" returns inner-and-outer elements for nested matches', () => {
       setup();
-      const outerNested = eqn.getElementsInForm('nested', 'outer', 'all');
-      const innerNested = eqn.getElementsInForm('nested', 'inner', 'all');
+      const outerNested = eqn.getFunctionElements('outer', 'nested');
+      const innerNested = eqn.getFunctionElements('inner', 'nested');
       expect(outerNested.map(e => e.name)).toEqual(['a', 'b', 'c']);
       expect(innerNested.map(e => e.name)).toEqual(['b', 'c']);
     });
@@ -487,7 +494,7 @@ describe('Equation Functions - Container', () => {
       });
       figure.elements = eqn;
       figure.setFirstTransform();
-      const found = eqn.getElementsInForm('ann', 'insideAnnotation');
+      const found = eqn.getFunctionElements('insideAnnotation', 'ann');
       expect(found.map(e => e.name)).toEqual(['b', 'c']);
     });
   });


### PR DESCRIPTION
## Summary
- Rename `Equation.getElementsInForm` → `Equation.getFunctionElements`. **Breaking change relative to 1.4.0**, which shipped the original name minutes earlier — no external consumers expected.
- Reorder parameters to `(name, formName? = null, mode = 'all', includeHidden = false)`; `name` now comes first and `formName` defaults to the current form.
- Flip the default `mode` from `'first'` to `'all'`.