### PR TITLE
Add formChanged notifications to Equation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 1.5.0
+* Add `formChanged` notification on `Equation` with phases `showForm`, `goToFormStart`, `goToFormStep` (with `progress` 0–1), and `goToFormEnd`, so listeners can drive UI from form transitions
+* Add optional `notify` parameter to `Equation.showForm` (defaults to `true`); pass `false` to suppress the `formChanged` event for that call
+
 ## 1.4.1
 * **Breaking (relative to 1.4.0):** rename `Equation.getElementsInForm` → `Equation.getFunctionElements`
 * Reorder parameters to `(name, formName? = null, mode = 'all', includeHidden = false)` — `name` is now first, `formName` defaults to the current form, and `mode` defaults to `'all'`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/Equation/Equation.ts
+++ b/src/js/figure/Equation/Equation.ts
@@ -939,6 +939,32 @@ class GoToFormAnimationStep extends TriggerAnimationStep {
  * * {@link GoToFormAnimationStep}
  * * {@link NextFormAnimationStep}
  *
+ * In addition to the notifications published by {@link FigureElement}, an
+ * Equation publishes a `formChanged` notification whenever the displayed form
+ * may have changed. The payload is an object
+ * `{ phase, form, fromForm?, progress? }` where `phase` is one of:
+ * - `'showForm'`: a form was set via `showForm`. Callers can suppress this
+ *   event by passing `notify: false` to `showForm`; internal `showForm`
+ *   calls made by `goToForm` do this so the `goToForm*` event stream is
+ *   not interleaved with stray `showForm` events.
+ * - `'goToFormStart'`: a `goToForm` call has just begun
+ * - `'goToFormStep'`: published on every animation frame during a `goToForm`
+ *   animation; `progress` is the percentage (0-1) through the animation. A
+ *   final `goToFormStep` with `progress: 1` is always published immediately
+ *   before `goToFormEnd`
+ * - `'goToFormEnd'`: a `goToForm` call has finished
+ *
+ *  * `fromForm` is only included on the `goToForm*` phases (it carries the
+ * `fromWhere` option from `goToForm`); it is absent on `showForm`. `progress`
+ * is only included on `goToFormStep`. The event order for a `goToForm` call
+ * is always: `goToFormStart` → zero-or-more `goToFormStep` → `goToFormStep`
+ * with `progress: 1` → `goToFormEnd`.
+ *
+ * A user-initiated `showForm` made while a `goToForm` animation is running
+ * will publish its `showForm` event interleaved with the ongoing
+ * `goToFormStep` stream — listeners that drive UI from "the current
+ * transition" should account for this. Pass `notify: false` to suppress.
+ *
  * @extends FigureElementCollection
  *
  * @see To test examples, append them to the
@@ -2189,6 +2215,7 @@ export class Equation extends FigureElementCollection {
     this.stopAnimating(how, '_Equation', true);
     this.stopAnimating(how, '_EquationColor', true);
     this.stopAnimating(how, '_EquationAnimateColor', true);
+    this.stopAnimating(how, '_EquationFormStep', true);
     this.stopPulsing(how);
   }
 
@@ -2400,14 +2427,27 @@ export class Equation extends FigureElementCollection {
   /**
    * Show equation form
    */
+  /**
+   * Show equation form.
+   *
+   * @param formOrName the form, or its name, to show
+   * @param animationStop if `true`, stops any in-progress element animations
+   * before rendering the form (default `true`)
+   * @param notify if `true`, publish a `formChanged` notification with
+   * `phase: 'showForm'` (default `true`). Pass `false` to suppress the
+   * event — useful for bulk updates or when this `showForm` is part of a
+   * larger transition the caller is broadcasting separately. The internal
+   * `showForm` calls made by `goToForm` use `false` so the `goToForm*`
+   * event stream is not interleaved with stray `showForm` events.
+   */
   showForm(
     formOrName: EquationForm | string = this.eqn.currentForm,
     // subForm: ?string = null,
     animationStop: boolean = true,
     // showCollection: boolean = true,
+    notify: boolean = true,
   ) {
     super.show();
-    // this.custom.settingForm = true;
     let form: EquationForm | string | null = formOrName;
     if (typeof formOrName === 'string') {
       form = this.getForm(formOrName);
@@ -2418,6 +2458,11 @@ export class Equation extends FigureElementCollection {
       this.render(animationStop);
       this.fnMap.exec((form as EquationForm).onTransition);
       this.fnMap.exec((form as EquationForm).onShow);
+      if (notify) {
+        this.notifications.publish('formChanged', {
+          phase: 'showForm', form: form as EquationForm,
+        });
+      }
     }
   }
 
@@ -2487,7 +2532,7 @@ export class Equation extends FigureElementCollection {
         // this.stopEquationAnimating('complete');
         const currentForm = this.getCurrentForm();
         if (currentForm != null) {
-          this.showForm(currentForm);
+          this.showForm(currentForm, true, false);
         }
       } else {
         // this.stopEquationAnimating('cancel');
@@ -2581,18 +2626,49 @@ export class Equation extends FigureElementCollection {
       }
     }
     if (duration === 0) {
-      this.showForm(form);
+      this.notifications.publish('formChanged', {
+        phase: 'goToFormStart', form, fromForm: options.fromWhere,
+      });
+      this.showForm(form, true, false);
       this.fnMap.exec(options.callback);
+      this.notifications.publish('formChanged', {
+        phase: 'goToFormStep', form, fromForm: options.fromWhere, progress: 1,
+      });
+      this.notifications.publish('formChanged', {
+        phase: 'goToFormEnd', form, fromForm: options.fromWhere,
+      });
     } else {
       this.eqn.isAnimating = true;
       this.fnMap.exec(onTransition);
+      // Set the current form before publishing goToFormStart so listeners
+      // that call getCurrentForm() see the target form, matching the payload.
+      this.setCurrentForm(form);
+      this.notifications.publish('formChanged', {
+        phase: 'goToFormStart', form, fromForm: options.fromWhere,
+      });
+      let stepStarted = false;
       const end = () => {
         this.fnMap.exec(form.onShow);
         this.eqn.isAnimating = false;
         this.fnMap.exec(options.callback);
+        // Cancelling the step ticker stops any further frame callbacks
+        // after end(). It cannot retract a step(p:1) the ticker may have
+        // already published earlier in this frame, so the ticker callback
+        // also skips p===1 — the manual publish below is the single
+        // canonical terminal step event.
+        if (stepStarted) {
+          this.stopAnimating('cancel', '_EquationFormStep', true);
+        }
+        this.notifications.publish('formChanged', {
+          phase: 'goToFormStep', form, fromForm: options.fromWhere, progress: 1,
+        });
+        this.notifications.publish('formChanged', {
+          phase: 'goToFormEnd', form, fromForm: options.fromWhere,
+        });
       };
+      let totalTime = 0;
       if (options.animate === 'move') {
-        form.animatePositionsTo(
+        totalTime = form.animatePositionsTo(
           options.delay,
           options.dissolveOutTime,
           duration,
@@ -2602,7 +2678,7 @@ export class Equation extends FigureElementCollection {
           false,
         );
       } else if (options.animate === 'dissolveInThenMove') {
-        form.animatePositionsTo(
+        totalTime = form.animatePositionsTo(
           options.delay,
           options.dissolveOutTime,
           duration,
@@ -2628,7 +2704,7 @@ export class Equation extends FigureElementCollection {
           start = getPoint(this.eqn.formRestart.moveFrom as any);
         }
         const showFormCallback = () => {
-          this.showForm(form.name, false);
+          this.showForm(form.name, false, false);
         };
         this.fnMap.add('_equationShowFormCallback', showFormCallback);
         this.animations.new('_Equation')
@@ -2641,6 +2717,14 @@ export class Equation extends FigureElementCollection {
           .position({ target, duration })
           .whenFinished(end)
           .start();
+        if (duration != null) {
+          totalTime = options.delay + options.dissolveOutTime + 0.01 + duration;
+        } else {
+          // duration is null — the position step computes a velocity-based
+          // move time internally. Read it back from the chain we just
+          // started so the step ticker still covers the full animation.
+          totalTime = this.animations.getRemainingTime('_Equation');
+        }
       } else if (
         options.animate === 'pulse'
         && this.eqn.formRestart != null
@@ -2661,15 +2745,16 @@ export class Equation extends FigureElementCollection {
             (pulse.element as Equation).pulse({ duration: pulse.duration, scale: pulse.scale });
           }
         };
-        form.allHideShow(
+        const hideShowTime = form.allHideShow(
           options.delay,
           options.dissolveOutTime,
           options.blankTime,
           options.dissolveInTime,
           newEnd,
         );
+        totalTime = hideShowTime + (pulse.duration != null ? pulse.duration : 0);
       } else {
-        form.allHideShow(
+        totalTime = form.allHideShow(
           options.delay,
           options.dissolveOutTime,
           options.blankTime,
@@ -2677,7 +2762,27 @@ export class Equation extends FigureElementCollection {
           end,
         );
       }
-      this.setCurrentForm(form);
+      if (totalTime > 0) {
+        this.animations.new('_EquationFormStep')
+          .custom({
+            callback: (p: number) => {
+              // Skip the terminal tick — end() publishes the canonical
+              // step(p:1) so the ticker would otherwise duplicate it (and
+              // CustomAnimationStep can land on p=1 twice via
+              // nextFrame + finish()).
+              if (p >= 1) return;
+              this.notifications.publish('formChanged', {
+                phase: 'goToFormStep',
+                form,
+                fromForm: options.fromWhere,
+                progress: p,
+              });
+            },
+            duration: totalTime,
+          })
+          .start();
+        stepStarted = true;
+      }
     }
   }
 
@@ -2783,7 +2888,7 @@ export class Equation extends FigureElementCollection {
       this.eqn.isAnimating = false;
       const currentForm = this.getCurrentForm();
       if (currentForm != null) {
-        this.showForm(currentForm);
+        this.showForm(currentForm, true, false);
       }
       return;
     }

--- a/src/js/figure/Equation/EquationAnimations.test.ts
+++ b/src/js/figure/Equation/EquationAnimations.test.ts
@@ -432,4 +432,145 @@ describe('Equation Animation', () => {
       expect(state2.isFormIgnored).toBe(false);
     });
   });
+
+  describe('formChanged notification', () => {
+    test('showForm publishes phase:showForm', () => {
+      ways.simple();
+      const events = [];
+      eqn.notifications.add('formChanged', e => events.push(e));
+
+      eqn.showForm('0');
+      figure.drawNow(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].phase).toBe('showForm');
+      expect(events[0].form.name).toBe('0');
+      expect(events[0].fromForm).toBeUndefined();
+    });
+
+    test('getCurrentForm returns target inside goToFormStart listener', () => {
+      ways.simple();
+      eqn.showForm('0');
+      figure.drawNow(0);
+
+      let currentAtStart = null;
+      eqn.notifications.add('formChanged', (e) => {
+        if (e.phase === 'goToFormStart') {
+          currentAtStart = eqn.getCurrentForm().name;
+        }
+      });
+
+      eqn.goToForm({ form: '1', animate: 'dissolve', duration: 1 });
+      expect(currentAtStart).toBe('1');
+    });
+
+    test('goToForm publishes start, multiple steps, final step(p:1), and end', () => {
+      ways.simple();
+      eqn.showForm('0');
+      figure.drawNow(0);
+
+      const events = [];
+      eqn.notifications.add('formChanged', e => events.push({
+        phase: e.phase,
+        formName: e.form && e.form.name,
+        fromForm: e.fromForm,
+        progress: e.progress,
+      }));
+
+      eqn.goToForm({ form: '1', animate: 'dissolve', duration: 1 });
+      // _EquationFormStep covers the full animation; this self-checks the
+      // total against allHideShow's accounting.
+      const total = eqn.animations.getRemainingTime('_EquationFormStep');
+      expect(total).toBeGreaterThan(0);
+
+      figure.drawNow(0);
+      figure.drawNow(total * 0.25);
+      figure.drawNow(total * 0.5);
+      figure.drawNow(total * 0.75);
+      figure.drawNow(total + 0.1);
+
+      expect(events[0].phase).toBe('goToFormStart');
+      expect(events[0].formName).toBe('1');
+
+      const steps = events.filter(e => e.phase === 'goToFormStep');
+      expect(steps.length).toBeGreaterThanOrEqual(2);
+      steps.forEach((s) => {
+        expect(s.progress).toBeGreaterThanOrEqual(0);
+        expect(s.progress).toBeLessThanOrEqual(1);
+      });
+
+      // last step is exactly progress:1 (no duplicates), immediately
+      // followed by goToFormEnd, which is the last event
+      const endIndex = events.findIndex(e => e.phase === 'goToFormEnd');
+      expect(endIndex).toBeGreaterThan(0);
+      expect(events[endIndex - 1].phase).toBe('goToFormStep');
+      expect(events[endIndex - 1].progress).toBe(1);
+      // only one terminal step(p:1)
+      expect(steps.filter(s => s.progress === 1)).toHaveLength(1);
+      expect(endIndex).toBe(events.length - 1);
+    });
+
+    test('animate:move publishes a complete event stream', () => {
+      ways.simple();
+      eqn.showForm('1');           // ['b','c']
+      figure.drawNow(0);
+
+      const events = [];
+      eqn.notifications.add('formChanged', e => events.push({
+        phase: e.phase, progress: e.progress,
+      }));
+
+      // form '2' = ['a','b'] — c dissolves out, a dissolves in, b may move
+      eqn.goToForm({ form: '2', animate: 'move', duration: 1 });
+      const total = eqn.animations.getRemainingTime('_EquationFormStep');
+      expect(total).toBeGreaterThan(0);
+
+      figure.drawNow(0);
+      figure.drawNow(total * 0.5);
+      figure.drawNow(total + 0.1);
+
+      const phases = events.map(e => e.phase);
+      expect(phases[0]).toBe('goToFormStart');
+      expect(phases[phases.length - 1]).toBe('goToFormEnd');
+      const steps = events.filter(e => e.phase === 'goToFormStep');
+      expect(steps.length).toBeGreaterThanOrEqual(1);
+      expect(steps[steps.length - 1].progress).toBe(1);
+    });
+
+    test('duration:0 goToForm publishes only goToForm* phases, no showForm', () => {
+      ways.simple();
+      eqn.showForm('0');
+      figure.drawNow(0);
+
+      const events = [];
+      eqn.notifications.add('formChanged', e => events.push({
+        phase: e.phase, progress: e.progress,
+      }));
+
+      eqn.goToForm({ form: '1', animate: 'dissolve', duration: 0 });
+
+      const phases = events.map(e => e.phase);
+      expect(phases).toEqual(['goToFormStart', 'goToFormStep', 'goToFormEnd']);
+      expect(events[1].progress).toBe(1);
+    });
+
+    test('internal showForm during goToForm interruption does not publish showForm', () => {
+      ways.simple();
+      eqn.showForm('0');
+      figure.drawNow(0);
+
+      // Start an animated goToForm
+      eqn.goToForm({ form: '1', animate: 'dissolve', duration: 1 });
+      figure.drawNow(0);
+      figure.drawNow(0.3);
+
+      const events = [];
+      eqn.notifications.add('formChanged', e => events.push(e.phase));
+
+      // Interrupt with another goToForm — skipToTarget runs an internal
+      // showForm to snap to current, which must not emit 'showForm'.
+      eqn.goToForm({ form: '2', animate: 'dissolve', duration: 1 });
+      expect(events).not.toContain('showForm');
+    });
+  });
 });

--- a/src/js/figure/Equation/EquationForm.ts
+++ b/src/js/figure/Equation/EquationForm.ts
@@ -520,7 +520,7 @@ export default class EquationForm extends Elements {
     blankTime: number = 0.5,
     showTime: number = 0.5,
     callback: ((cancelled: boolean) => void) | null = null,
-  ) {
+  ): number {
     this.collectionMethods.stop();
     const allElements = this.collectionMethods.getAllElements();
     const elementsShown = allElements.filter(e => e.isShown && !e.isFormIgnored);
@@ -533,8 +533,8 @@ export default class EquationForm extends Elements {
     if (elementsToShow.length === 0 && elementsShown.length === 0) {
       if (callback != null) {
         callback(false);
-        return;
       }
+      return 0;
     }
 
     let dissolveOutCallback: any = () => {
@@ -584,6 +584,13 @@ export default class EquationForm extends Elements {
         })
         .start();
     });
+    if (elementsToShow.length > 0) {
+      cumTime += blankTime + showTime;
+    }
+    // Upper bound on the total animation time: when elementsToDelayShowing
+    // finish their dissolveIn. elementsToShowAfterDissolve are scheduled with
+    // `delay: blankTime` (not `cumTime + blankTime`) so they may finish earlier.
+    return cumTime;
   }
 
   applyElementMods(fromWhere: null | string = null) {


### PR DESCRIPTION
## Summary
- Equation now publishes a `formChanged` notification with phases `showForm`, `goToFormStart`, `goToFormStep` (with `progress`), and `goToFormEnd` so callers can drive UI from form transitions
- `showForm` gains a `notify` parameter; internal `showForm` calls from `goToForm` pass `false` to avoid interleaving stray events into the `goToForm*` stream
- `EquationForm.allHideShow` and step-ticker plumbing now report total animation duration, enabling a single canonical `goToFormStep(progress: 1)` immediately before `goToFormEnd`