### PR TITLE
Add opacity equation function with multiplicative cascade

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 1.6.0
+* Add `opacity` equation layout function (`EQN_Opacity`) — wraps an equation phrase in an opacity multiplier that cascades multiplicatively through nested wrappers (outer 0.5 × inner 0.5 = 0.25 on inner content)
+* Add `ignoreOpacity` form option (parallel to `ignoreColor`); set `true` to preserve externally-set element opacities and suppress the cascade
+* Add `{ color: EQN_Color }` and `{ opacity: EQN_Opacity }` to the `TypeEquationPhrase` union (the `color` union entry was previously missing) and fix `addFormFullObject` so per-form `ignoreColor` / `ignoreOpacity` are honored instead of silently dropped
+
 ## 1.5.0
 * Add `formChanged` notification on `Equation` with phases `showForm`, `goToFormStart`, `goToFormStep` (with `progress` 0–1), and `goToFormEnd`, so listeners can drive UI from form transitions
 * Add optional `notify` parameter to `Equation.showForm` (defaults to `true`); pass `false` to suppress the `formChanged` event for that call

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/Equation/Elements/BaseAnnotationFunction.ts
+++ b/src/js/figure/Equation/Elements/BaseAnnotationFunction.ts
@@ -183,6 +183,12 @@ function setColorForAnnotations(annotations: Array<EQN_Annotation>, color: TypeC
   });
 }
 
+function setOpacityForAnnotations(annotations: Array<EQN_Annotation>, opacity: number) {
+  annotations.forEach((annotation) => {
+    annotation.content.setOpacity(opacity);
+  });
+}
+
 
 function setPositionsForGlyphs(glyphs: EQN_Glyphs) {
   Object.keys(glyphs).forEach((key) => {
@@ -217,6 +223,17 @@ function setColorForGlyphs(glyphs: EQN_Glyphs, color: TypeColor | null) {
   });
 }
 
+function setOpacityForGlyphs(glyphs: EQN_Glyphs, opacity: number) {
+  Object.keys(glyphs).forEach((key) => {
+    if ((glyphs as any)[key] == null) {
+      return;
+    }
+    const glyph = (glyphs as any)[key];
+    glyph.glyph.setOpacity(opacity);
+    setOpacityForAnnotations(glyph.annotations, opacity);
+  });
+}
+
 function offsetLocationForGlyphs(glyphs: EQN_Glyphs, offset: Point) {
   Object.keys(glyphs).forEach((key) => {
     if ((glyphs as any)[key] == null) {
@@ -237,6 +254,7 @@ export default class BaseAnnotationFunction implements ElementInterface {
   scale: number;
   showContent: boolean;
   color: TypeColor | null;
+  opacity: number | null;
   fullSize!: {
     leftOffset: number,
     width: number,
@@ -271,6 +289,7 @@ export default class BaseAnnotationFunction implements ElementInterface {
     this.showContent = showContent;
     this.scale = 1;
     this.color = null;
+    this.opacity = null;
     this.functionName = null;
   }
 
@@ -319,6 +338,16 @@ export default class BaseAnnotationFunction implements ElementInterface {
     this.content.setColor(color);
     setColorForAnnotations(this.annotations, color);
     setColorForGlyphs(this.glyphs, color);
+  }
+
+  setOpacity(opacityIn: number = 1) {
+    let opacity = opacityIn;
+    if (this.opacity != null) {
+      opacity *= this.opacity;
+    }
+    this.content.setOpacity(opacity);
+    setOpacityForAnnotations(this.annotations, opacity);
+    setOpacityForGlyphs(this.glyphs, opacity);
   }
 
   offsetLocation(offset: Point = new Point(0, 0)) {

--- a/src/js/figure/Equation/Elements/BaseEquationFunction.ts
+++ b/src/js/figure/Equation/Elements/BaseEquationFunction.ts
@@ -139,6 +139,23 @@ export default class BaseEquationFunction extends Elements {
     });
   }
 
+  override setOpacity(opacityIn: number = 1) {
+    let opacity = opacityIn;
+    if (this.opacity != null) {
+      opacity *= this.opacity;
+    }
+    this.glyphs.forEach((glyph) => {
+      if (glyph != null) {
+        glyph.setOpacity(opacity);
+      }
+    });
+    this.contents.forEach((content) => {
+      if (content != null) {
+        content.setOpacity(opacity);
+      }
+    });
+  }
+
   override offsetLocation(offset: Point = new Point(0, 0)) {
     this.location = this.location.add(offset);
     this.glyphLocations.forEach((glyphLocation, index) => {

--- a/src/js/figure/Equation/Elements/Element.ts
+++ b/src/js/figure/Equation/Elements/Element.ts
@@ -34,6 +34,7 @@ export interface ElementInterface {
   getBounds(useFullSize?: boolean): Bounds;
   cleanup(): void;
   setColor(colorIn: TypeColor | null): void;
+  setOpacity(opacityIn: number): void;
 }
 
 // Equation is a class that takes a set of drawing objects (TextObjects,
@@ -71,6 +72,7 @@ class Element implements ElementInterface {
   showContent: boolean;
   color: TypeColor | null;
   defaultColor: TypeColor;
+  opacity: number | null;
   fullSize: {
     leftOffset: number,
     width: number,
@@ -96,6 +98,7 @@ class Element implements ElementInterface {
     };
     this.color = null;
     this.defaultColor = content.color.slice();
+    this.opacity = null;
     this.fnMap = new FunctionMap();
     this.showContent = true;
   }
@@ -223,6 +226,21 @@ class Element implements ElementInterface {
     }
   }
 
+  setOpacity(opacityIn: number = 1) {
+    let opacity = opacityIn;
+    if (this.opacity != null) {
+      opacity *= this.opacity;
+    }
+    const { content } = this;
+    if (content instanceof FigureElementCollection
+        || content instanceof FigureElementPrimitive) {
+      if (content.isFormIgnored) {
+        return;
+      }
+      content.setOpacity(opacity);
+    }
+  }
+
   offsetLocation(offset: Point = new Point(0, 0)) {
     this.location = this.location.add(offset);
   }
@@ -263,6 +281,7 @@ class Elements implements ElementInterface {
   fnMap: FunctionMap;
   showContent: boolean;
   color: TypeColor | null;
+  opacity: number | null;
   fullSize!: {
     leftOffset: number,
     width: number,
@@ -287,6 +306,7 @@ class Elements implements ElementInterface {
     this.fnMap = new FunctionMap();
     this.showContent = true;
     this.color = null;
+    this.opacity = null;
   }
 
   cleanup() {
@@ -370,6 +390,16 @@ class Elements implements ElementInterface {
     }
     this.content.forEach((e) => {
       e.setColor(color);
+    });
+  }
+
+  setOpacity(opacityIn: number = 1) {
+    let opacity = opacityIn;
+    if (this.opacity != null) {
+      opacity *= this.opacity;
+    }
+    this.content.forEach((e) => {
+      e.setOpacity(opacity);
     });
   }
 

--- a/src/js/figure/Equation/Elements/Opacity.ts
+++ b/src/js/figure/Equation/Elements/Opacity.ts
@@ -1,0 +1,38 @@
+import {
+  Point,
+} from '../../../tools/g2';
+import Bounds from './Bounds';
+import BaseEquationFunction from './BaseEquationFunction';
+
+
+export default class Opacity extends BaseEquationFunction {
+  override opacity!: number | null;
+
+  override calcSize(location: Point, scale: number) {
+    this.location = location._dup();
+    const loc = location._dup();
+    const {
+      opacity, fullContentBounds,
+    } = this.options;
+    const [mainContent] = this.contents;
+    const contentBounds = new Bounds();
+    const fullBounds = new Bounds();
+    if (mainContent != null) {
+      mainContent.calcSize(loc._dup(), scale);
+      contentBounds.copyFrom(mainContent.getBounds(fullContentBounds));
+      fullBounds.copyFrom(mainContent.getBounds(true));
+    }
+    this.opacity = opacity;
+    this.width = contentBounds.width;
+    this.height = contentBounds.height;
+    this.descent = contentBounds.descent;
+    this.ascent = contentBounds.ascent;
+    this.fullSize = {
+      leftOffset: this.location.x - fullBounds.left,
+      width: fullBounds.width,
+      ascent: fullBounds.ascent,
+      descent: fullBounds.descent,
+      height: fullBounds.height,
+    };
+  }
+}

--- a/src/js/figure/Equation/Equation.ts
+++ b/src/js/figure/Equation/Equation.ts
@@ -491,6 +491,11 @@ export type EQN_FromForms = {
  * automatically in the equation based on EQN_Color equation functions. In such
  * cases, colors that are set external to the equation will be overridden. Use
  * `true` to allow setting of colors externally only. (`false`)
+ * @property {boolean} [ignoreOpacity] when `false`, opacity will be set
+ * automatically in the equation based on EQN_Opacity equation functions
+ * (multiplicative cascade). Element opacities set externally will be
+ * overridden. Use `true` to allow setting of opacities externally only.
+ * (`false`)
  *
  * @example
  * // Simple form definition of two different forms of the same equation and one
@@ -582,6 +587,7 @@ type EQN_FormObjectDefinition = {
   elementMods?: OBJ_ElementMods;
   fromForm: EQN_FromForms;
   ignoreColor?: boolean;
+  ignoreOpacity?: boolean;
 };
 
 
@@ -697,6 +703,7 @@ export type EQN_FormDefaults = {
   onTransition?: null | string | (() => void);
   layout?: 'lazy' | 'init' | 'always';
   ignoreColor?: boolean;
+  ignoreOpacity?: boolean;
 }
 
 /**
@@ -1057,6 +1064,7 @@ export class Equation extends FigureElementCollection {
       onTransition?: null | string | (() => void);
       layout?: 'always' | 'lazy' | 'init';
       ignoreColor?: boolean;
+      ignoreOpacity?: boolean;
     };
 
     isAnimating: boolean;
@@ -1134,6 +1142,7 @@ export class Equation extends FigureElementCollection {
         elementMods: {},
         layout: 'always',
         ignoreColor: false,
+        ignoreOpacity: false,
         // lazyLayout: true,
         // layoutonce: false,
       },
@@ -1226,6 +1235,7 @@ export class Equation extends FigureElementCollection {
         translation: optionsToUse.formDefaults.translation,
         layout: optionsToUse.formDefaults.layout,
         ignoreColor: optionsToUse.formDefaults.ignoreColor,
+        ignoreOpacity: optionsToUse.formDefaults.ignoreOpacity,
       },
       functions: new EquationFunctions(
         this.elements as any,
@@ -1966,6 +1976,7 @@ export class Equation extends FigureElementCollection {
         elementMods, duration, alignment, scale,
         description, modifiers, translation,
         fromForm, onShow, onTransition,
+        ignoreColor, ignoreOpacity,
       } = form as any;
       const options = {
         elementMods,
@@ -1978,6 +1989,8 @@ export class Equation extends FigureElementCollection {
         translation,
         onShow,
         onTransition,
+        ignoreColor,
+        ignoreOpacity,
       };
       try {
         this.addForm(name, formContent, options);
@@ -2274,7 +2287,7 @@ export class Equation extends FigureElementCollection {
     }
     const {
       description, modifiers, fromForm,
-      onShow, onTransition, duration, translation, ignoreColor,
+      onShow, onTransition, duration, translation, ignoreColor, ignoreOpacity,
     } = optionsToUse;
     const form = this.createForm();
     this.eqn.forms[name] = form;
@@ -2287,6 +2300,7 @@ export class Equation extends FigureElementCollection {
     form.onShow = onShow;
     form.onTransition = onTransition;
     form.ignoreColor = ignoreColor;
+    form.ignoreOpacity = ignoreOpacity;
 
     // Populate element mods
     form.elementMods = {};

--- a/src/js/figure/Equation/EquationForm.ts
+++ b/src/js/figure/Equation/EquationForm.ts
@@ -138,6 +138,7 @@ export default class EquationForm extends Elements {
   positionsSet: boolean;
   layout: 'always' | 'lazy' | 'init';
   ignoreColor: boolean;
+  ignoreOpacity: boolean;
   // };
 
   fromForm: {
@@ -176,6 +177,7 @@ export default class EquationForm extends Elements {
     this.positionsSet = false;
     this.layout = 'always';
     this.ignoreColor = false;
+    this.ignoreOpacity = false;
     // this.subForm = '';
   }
 
@@ -207,6 +209,9 @@ export default class EquationForm extends Elements {
     super.setPositions();
     if (!this.ignoreColor) {
       super.setColor();
+    }
+    if (!this.ignoreOpacity) {
+      super.setOpacity();
     }
   }
 

--- a/src/js/figure/Equation/EquationFunctions.ts
+++ b/src/js/figure/Equation/EquationFunctions.ts
@@ -22,6 +22,7 @@ import BaseEquationFunction from './Elements/BaseEquationFunction';
 import EquationLine from './Symbols/Line';
 import Offset from './Elements/Offset';
 import Color from './Elements/Color';
+import Opacity from './Elements/Opacity';
 import type { TypeColor } from '../../tools/types';
 
 // import type {
@@ -83,6 +84,8 @@ export function getFigureElement(
  *  - `{ prodOf: `{@link EQN_ProdOf} `}`
  *  - `{ topStrike: `{@link EQN_StrikeComment} `}`
  *  - `{ bottomStrike: `{@link EQN_StrikeComment} `}`
+ *  - `{ color: `{@link EQN_Color} `}`
+ *  - `{ opacity: `{@link EQN_Opacity} `}`
  *  - `{ make: string, name?: string, ... }` (inline element — creates any
  *    element type directly in a form using the same `make` values as
  *    {@link Figure.add}. If `name` is omitted, one is auto-generated.)
@@ -156,6 +159,8 @@ export type TypeEquationPhrase =
   | { prodOf: EQN_ProdOf }
   | { topStrike: EQN_StrikeComment }
   | { bottomStrike: EQN_StrikeComment }
+  | { color: EQN_Color }
+  | { opacity: EQN_Opacity }
   | { make: string, name?: string, [key: string]: any }
   | Array<TypeEquationPhrase>
   | FigureElementPrimitive
@@ -596,6 +601,68 @@ export type EQN_Color = {
 } | [
   TypeEquationPhrase,
   TypeColor,
+  (boolean | null | undefined),
+];
+
+/**
+ * Equation opacity function
+ *
+ * Set an opacity multiplier on an equation phrase. The opacity cascades
+ * multiplicatively, so nested `opacity` functions multiply together (e.g. an
+ * outer `0.5` around an inner `0.5` yields `0.25` on the inner content).
+ *
+ * Opacity values are expected to be in the range `[0, 1]`. Whenever the form
+ * is shown, the cascaded opacity is assigned to each wrapped element, overriding
+ * any externally-set element `opacity`. Set `ignoreOpacity: true` on the form
+ * to suppress this and preserve externally-set opacities.
+ *
+ * Options can be an object, or an array in the property order below
+ *
+ * @property {TypeEquationPhrase} content
+ * @property {number} opacity opacity multiplier in the range `[0, 1]`
+ * @property {boolean} [fullContentBounds] Use full bounds with content (`false`)
+ *
+ * @see To test examples, append them to the
+ * <a href="#drawing-boilerplate">boilerplate</a>
+ *
+ * @example
+ * // Simple Array Definition
+ * figure.add({
+ *   make: 'equation',
+ *   forms: {
+ *     0: ['a', { opacity: ['b', 0.3] }, 'c'],
+ *   },
+ * });
+ *
+ * @example
+ * // Simple Object Definition
+ * figure.add({
+ *   make: 'equation',
+ *   forms: {
+ *     0: [
+ *       'a',
+ *       {
+ *         opacity: {
+ *           content: 'b',
+ *           opacity: 0.3,
+ *         },
+ *       },
+ *       'c',
+ *     ],
+ *   },
+ * });
+ *
+ * @interface
+ * @group Equation Layout
+ */
+export type EQN_Opacity = {
+  content: TypeEquationPhrase,
+  opacity: number,
+  fullContentBounds?: boolean;
+  name?: string,
+} | [
+  TypeEquationPhrase,
+  number,
   (boolean | null | undefined),
 ];
 
@@ -3509,6 +3576,7 @@ export class EquationFunctions {
     if (name === 'container') { return this.container(params); }
     if (name === 'offset') { return this.offset(params); }
     if (name === 'color') { return this.color(params); }
+    if (name === 'opacity') { return this.opacity(params); }
     return null;
   }
 
@@ -4100,6 +4168,45 @@ export class EquationFunctions {
       );
     } catch (e: any) {
       throw new Error(`FigureOne Equation Color Error: ${e.message}`);
+    }
+  }
+
+  /**
+   * Equation opacity function
+   * @see {@link EQN_Opacity} for description and examples
+   */
+  opacity(
+    options: EQN_Opacity,
+  ) {
+    try {
+      let content;
+      let opacity;
+      let fullContentBounds;
+      const defaultOptions = {
+        opacity: null,
+        fullContentBounds: false,
+      };
+      if (Array.isArray(options)) {
+        [
+          content, opacity, fullContentBounds,
+        ] = options;
+      } else {
+        ({
+          content, opacity, fullContentBounds,
+        } = options);
+      }
+      const optionsIn = {
+        opacity,
+        fullContentBounds,
+      };
+      const o = joinObjects<any>(defaultOptions, optionsIn);
+      return new Opacity(
+        [this.contentToElement(content)],
+        [],
+        o,
+      );
+    } catch (e: any) {
+      throw new Error(`FigureOne Equation Opacity Error: ${e.message}`);
     }
   }
 

--- a/src/js/figure/Equation/FunctionTests/Equation.opacity.test.ts
+++ b/src/js/figure/Equation/FunctionTests/Equation.opacity.test.ts
@@ -1,0 +1,151 @@
+import {
+  round,
+} from '../../../tools/math';
+import * as tools from '../../../tools/tools';
+import makeFigure from '../../../__mocks__/makeFigure';
+import { Equation } from '../Equation';
+
+tools.isTouchDevice = jest.fn();
+
+jest.mock('../../Gesture');
+jest.mock('../../webgl/webgl');
+jest.mock('../../DrawContext2D');
+
+describe('Equation Functions - Opacity', () => {
+  let figure;
+  let eqn;
+  let elements;
+  let functions;
+  beforeEach(() => {
+    figure = makeFigure();
+    elements = {
+      a: 'a',
+      b: 'b',
+      c: 'c',
+      v: { symbol: 'vinculum' },
+    };
+    functions = {
+      inputForms: () => {
+        eqn = new Equation(figure.shapes, { color: [1, 0, 0, 1] });
+        const e = eqn.eqn.functions;
+        const opacity = e.opacity.bind(e);
+        eqn.addElements(elements);
+        eqn.addForms({
+          // Full Object
+          base: {
+            content: {
+              opacity: {
+                content: ['a', 'b', 'c'],
+                opacity: 0.5,
+              },
+            },
+          },
+          // Method Object
+          1: { opacity: { content: ['a', 'b', 'c'], opacity: 0.5 } },
+          // Method Array
+          2: { opacity: [['a', 'b', 'c'], 0.5] },
+          // Function with Method Array
+          3: e.opacity([['a', 'b', 'c'], 0.5]),
+          // Bound Function with Object
+          4: opacity([['a', 'b', 'c'], 0.5]),
+          // Nested — multiplicative: 0.5 * 0.5 = 0.25
+          nested: {
+            opacity: {
+              content: { opacity: [['a', 'b', 'c'], 0.5] },
+              opacity: 0.5,
+            },
+          },
+          // Partial — only `b` inside opacity wrapper
+          partial: ['a', { opacity: ['b', 0.4] }, 'c'],
+          // No opacity wrapper — leaves should stay at 1
+          plain: ['a', 'b', 'c'],
+          // Opacity wrapper present, but ignoreOpacity suppresses the cascade
+          ignored: {
+            content: { opacity: [['a', 'b', 'c'], 0.5] },
+            ignoreOpacity: true,
+          },
+          // Opacity zero — should cascade through and apply
+          zero: { opacity: [['a', 'b', 'c'], 0] },
+          // Opacity wrapping a fraction — exercises glyph/content cascade
+          frac: { opacity: [{ frac: ['a', 'v', 'b'] }, 0.5] },
+        });
+        figure.elements = eqn;
+      },
+    };
+  });
+
+  test('Equivalent definitions all produce 0.5 opacity', () => {
+    functions.inputForms();
+    const elems = [eqn._a, eqn._b, eqn._c];
+    ['base', '1', '2', '3', '4'].forEach((f) => {
+      eqn.showForm(f);
+      figure.setFirstTransform();
+      const opacities = elems.map(elem => round(elem.opacity, 4));
+      expect(opacities).toEqual([0.5, 0.5, 0.5]);
+    });
+
+    eqn.showForm('base');
+    figure.setFirstTransform();
+    tools.cleanUIDs(eqn);
+    expect(round(eqn._a.transform.mat)).toMatchSnapshot();
+    expect(round(eqn._b.transform.mat)).toMatchSnapshot();
+    expect(round(eqn._c.transform.mat)).toMatchSnapshot();
+  });
+
+  test('Opacity zero cascades to wrapped elements', () => {
+    functions.inputForms();
+    eqn.showForm('zero');
+    figure.setFirstTransform();
+    [eqn._a, eqn._b, eqn._c].forEach((elem) => {
+      expect(round(elem.opacity, 4)).toEqual(0);
+    });
+  });
+
+  test('Opacity applies to glyphs and content of an annotated function', () => {
+    functions.inputForms();
+    eqn.showForm('frac');
+    figure.setFirstTransform();
+    expect(round(eqn._a.opacity, 4)).toEqual(0.5);
+    expect(round(eqn._b.opacity, 4)).toEqual(0.5);
+    expect(round(eqn._v.opacity, 4)).toEqual(0.5);
+  });
+
+  test('Nested opacity multiplies', () => {
+    functions.inputForms();
+    eqn.showForm('nested');
+    figure.setFirstTransform();
+    const opacities = [eqn._a, eqn._b, eqn._c].map(elem => round(elem.opacity, 4));
+    expect(opacities).toEqual([0.25, 0.25, 0.25]);
+  });
+
+  test('Partial opacity only affects wrapped content', () => {
+    functions.inputForms();
+    eqn.showForm('partial');
+    figure.setFirstTransform();
+    expect(round(eqn._a.opacity, 4)).toEqual(1);
+    expect(round(eqn._b.opacity, 4)).toEqual(0.4);
+    expect(round(eqn._c.opacity, 4)).toEqual(1);
+  });
+
+  test('No opacity wrapper leaves opacity at default', () => {
+    functions.inputForms();
+    eqn.showForm('plain');
+    figure.setFirstTransform();
+    [eqn._a, eqn._b, eqn._c].forEach((elem) => {
+      expect(round(elem.opacity, 4)).toEqual(1);
+    });
+  });
+
+  test('ignoreOpacity suppresses the cascade even with opacity wrapper', () => {
+    functions.inputForms();
+    // Externally set opacities first; cascade should not stomp them
+    eqn._a.setOpacity(0.2);
+    eqn._b.setOpacity(0.2);
+    eqn._c.setOpacity(0.2);
+    eqn.showForm('ignored');
+    figure.setFirstTransform();
+    [eqn._a, eqn._b, eqn._c].forEach((elem) => {
+      expect(round(elem.opacity, 4)).toEqual(0.2);
+    });
+  });
+});

--- a/src/js/figure/Equation/FunctionTests/__snapshots__/Equation.opacity.test.ts.snap
+++ b/src/js/figure/Equation/FunctionTests/__snapshots__/Equation.opacity.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Equation Functions - Opacity Equivalent definitions all produce 0.5 opacity 1`] = `
+[
+  0.7,
+  0,
+  0,
+  0,
+  0,
+  0.7,
+  0,
+  0,
+  0,
+  0,
+  1,
+  0,
+  0,
+  0,
+  0,
+  1,
+]
+`;
+
+exports[`Equation Functions - Opacity Equivalent definitions all produce 0.5 opacity 2`] = `
+[
+  0.7,
+  0,
+  0,
+  0.07,
+  0,
+  0.7,
+  0,
+  0,
+  0,
+  0,
+  1,
+  0,
+  0,
+  0,
+  0,
+  1,
+]
+`;
+
+exports[`Equation Functions - Opacity Equivalent definitions all produce 0.5 opacity 3`] = `
+[
+  0.7,
+  0,
+  0,
+  0.14,
+  0,
+  0.7,
+  0,
+  0,
+  0,
+  0,
+  1,
+  0,
+  0,
+  0,
+  0,
+  1,
+]
+`;


### PR DESCRIPTION
## Summary
- Adds an `opacity` equation layout function paralleling `color`. Wraps a
  phrase in an opacity multiplier that cascades multiplicatively through
  nested wrappers (outer 0.5 × inner 0.5 = 0.25 on the inner content).
- Adds a separate `ignoreOpacity` flag on equation forms (default `false`,
  parallel to `ignoreColor`) so external opacity animations can opt out of
  the cascade.
- Wires `{ color: EQN_Color }` and `{ opacity: EQN_Opacity }` into
  `TypeEquationPhrase` (color entry was previously missing) and fixes
  `addFormFullObject` to forward per-form `ignoreColor` / `ignoreOpacity`
  to `addForm` (previously dropped).

## Test plan
- [x] `docker exec figureone_dev npx tsc --noEmit` clean
- [x] `docker exec figureone_dev npm run jest` — 3079 / 3079 passing
- [x] New `Equation.opacity.test.ts` covers: equivalent definitions,
      multiplicative nesting, partial wrap, no-wrapper default,
      `ignoreOpacity: true` preserves externally-set opacities, opacity
      zero cascades, opacity wrapping a fraction reaches glyphs.
- [x] `npm run build:types` produces `EQN_Opacity`, `opacity()`,
      `ignoreOpacity`, and the new union members in `package/types/`.