### PR TITLE
Per-draw texture units and reference-counted shared atlases

### DIFF
--- a/TEXTURE_ATLAS_UPGRADE.md
+++ b/TEXTURE_ATLAS_UPGRADE.md
@@ -1,0 +1,144 @@
+# Texture & Atlas Subsystem Update — Upgrade Notes
+
+This release reworks FigureOne's internal WebGL texture and font-atlas management.
+**No public API changed.** Most consumers need to do nothing. If you remove
+individual text/GL elements at runtime while other same-font text stays on
+screen, read the "What you should do" section.
+
+Source commits: `Bind textures on each use`, `Reference-count shared textures`.
+
+---
+
+## TL;DR
+
+- Texture units are now assigned **per draw from a small shared pool** instead of
+  one permanent unit per texture. This removes a previously *silent* cap on the
+  number of distinct live textures.
+- Textures — including font atlases — are now **reference-counted**. Removing one
+  element that shares a font atlas no longer frees that atlas out from under
+  other elements still using it.
+- A missing/unloaded texture now **degrades safely** (the object skips its draw)
+  instead of crashing or sampling a stale texture.
+
+---
+
+## What changed in FigureOne
+
+### Per-draw texture unit allocation (bind-per-draw + bind-on-change)
+
+- **Before:** each texture was bound to a dedicated texture unit at upload and
+  kept there for its lifetime. The number of distinct live textures was therefore
+  silently capped at `MAX_COMBINED_TEXTURE_IMAGE_UNITS` (spec minimum 8; commonly
+  16–32 on mobile). Beyond that, textures stopped sampling with no error.
+- **After:** units are assigned per draw from a small shared pool (unit 0 is
+  reserved for the target/selector framebuffer texture). There is no longer a cap
+  on the number of distinct textures. A `bind-on-change` cache skips redundant
+  `bindTexture` calls, so runs of draws sharing a texture (e.g. text on one
+  atlas) still issue zero binds.
+- A one-time `Console` warning fires if a draw's unit budget would exceed
+  `MAX_TEXTURE_IMAGE_UNITS` (the fragment-shader sampler limit), so over-budget
+  use is diagnosable instead of silent.
+
+### Reference counting for textures (including font atlases)
+
+- **Before:** `deleteTexture` freed the GL texture immediately. The first owner's
+  `cleanup()` would delete a shared texture (e.g. a font atlas) out from under
+  other elements still using it — causing a crash, garbage render, or blank text.
+- **After:** each registered texture carries a reference count. `deleteTexture`
+  releases one reference; the GL texture is freed only when the last owner
+  releases it. Full teardown (`webgl.cleanup`) still hard-frees everything.
+- `GLText` now correctly **acquires** a reference to the atlas it adopts, balanced
+  by its release on cleanup. (Previously it released without acquiring, which is
+  the root of the shared-atlas-deletion bug above.)
+
+### Robustness fixes
+
+- A missing/unloaded **base texture** now causes the object to **skip its draw**
+  (render nothing this frame) rather than sampling whatever stale texture occupies
+  the unit, or throwing. (Composed texture shaders sample unconditionally, so
+  there is no safe in-shader fallback — skipping is the only garbage-free option.)
+- A missing **mask** is skipped cleanly instead of defaulting its sampler to the
+  reserved unit-0 framebuffer texture.
+- **Forced texture updates** (e.g. atlas re-render) now preserve pending `onLoad`
+  callbacks instead of dropping them.
+- The texture release is keyed on an internal `acquiredBaseTextureId` (the exact
+  id that was acquired), so it cannot over-release on a failed acquire and is
+  robust to consumers nulling `drawingObject.texture` before removal.
+
+### Internal rename
+
+- A texture's `index` field → `handle`: a stable monotonic id, **not** a texture
+  unit number. The numeric argument passed to texture `onLoad` callbacks is now
+  this handle. This is an internal field, not a public API.
+
+### Tests added
+
+Shared-atlas survival on partial teardown; font-change reference rebalancing;
+bind-on-change skip/rebind; acquire/over-release safety; and a regression test
+mirroring the downstream "detach then remove" cleanup workaround.
+
+---
+
+## What you should do on upgrade
+
+**1. If you have a shared-atlas cleanup workaround, you can remove it.**
+
+Some consumers wrote helpers to keep shared font atlases alive across element
+removal — e.g. calling `resetBuffers(false)`/`cleanup(deleteTexture=false)`,
+nulling `drawingObject.texture` before `remove()`, or otherwise dodging the
+default cleanup path. Reference counting makes these unnecessary: default
+`remove()` → `cleanup(true)` now only decrements the atlas's reference count and
+frees it when the last owner releases.
+
+- These workarounds are now **redundant but harmless** — the release is keyed on
+  an internal id, not on `texture.id`, so even nulling `texture` keeps the
+  reference count balanced (verified by a regression test that mirrors that exact
+  sequence).
+- **Action:** removing the workaround is safe and simplifies your teardown.
+  Verify once in your environment, then delete at your leisure. Keeping it also
+  works.
+
+**2. Re-check any resource-exhaustion handling.**
+
+Under the old model, every persisted atlas held a *permanent texture unit*. Apps
+that accumulate many atlases (e.g. across single-page-app view transitions) could
+exceed mobile unit limits (`MAX_COMBINED_TEXTURE_IMAGE_UNITS`, often 16–32) →
+textures silently stop sampling. The new per-draw unit pool means persisted
+atlases consume **zero** permanent units, removing that vector.
+
+- **Caveat:** this does **not** reduce atlas VRAM. If your exhaustion comes from
+  *memory*/context-loss (e.g. a `webglAvailable === false` path) rather than unit
+  count, this change won't help that. Check whether your symptoms were
+  blank-textures (unit cap → fixed) vs. context-lost (memory → unchanged).
+
+**3. No action needed for the `index` → `handle` rename.**
+
+Unless you read a texture's `index`/unit number directly or use the numeric
+argument passed to a texture `onLoad` callback, the rename does not affect you.
+
+---
+
+## Behavior change to be aware of
+
+Removing an element that shares a font atlas now **decrements** that atlas's
+reference count. Previously, workarounds that nulled `texture` dodged the
+decrement entirely. This is safe — the count cannot reach zero while the atlas's
+own `Atlas` object or any sibling element holds a reference — but if any of your
+code assumed a shared atlas's reference count only ever climbs, that assumption no
+longer holds.
+
+---
+
+## Known limitations / future work
+
+- **Atlas VRAM is not reclaimed mid-session.** An `Atlas` holds a permanent
+  reference to its texture for the figure's lifetime, so atlas textures are freed
+  only at full teardown (`webgl.cleanup`), even after all text using them is
+  removed. Making atlases reclaimable (releasing the `Atlas` reference on
+  eviction) is possible future work; it would also retire the `cleanup(false)`
+  calls in the equation code, which currently leave reference counts slightly
+  inflated but harmless.
+- **Async (URL-loaded custom font) atlases:** if an atlas texture isn't
+  registered yet when an element adopts it, no reference is taken; this degrades
+  to the safe "render nothing until loaded" behavior rather than a crash. The
+  common default-font (canvas) atlas path is synchronous and fully covered.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 1.9.0
+* WebGL textures, including shared font atlases, are now reference-counted, so removing one element that shares a font atlas no longer deletes the atlas out from under other elements still using it
+* Texture units are assigned per draw from a small shared pool instead of one permanent unit per texture, removing a silent cap on the number of distinct textures that could render at once; a missing or not-yet-loaded texture now skips its draw rather than rendering incorrectly
+
 ## 1.8.0
 * Add a `textureMap` color mode to the `gl` primitive that recolors regions of a base texture using mask textures — each mask's red, green, blue and alpha channels select up to four regions, each tinted by an entry of the new `tints` option
 * Support a single mask via `mask` or several via `masks`, where mask `m` uses `tints[4m]` through `tints[4m + 3]`; change region colors at runtime with the `setTint` / `setTints` element methods, with tint values captured in state for save/restore and recordings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/__mocks__/WebGLInstanceMock.ts
+++ b/src/js/__mocks__/WebGLInstanceMock.ts
@@ -55,9 +55,11 @@ const webgl = {
   lastUsedProgram: null,
   textures: {
     1: {
-      index: 1,
+      handle: 1,
     },
   },
+  boundUnits: [],
+  bindTextureToUnit: () => {},
   addTexture: () => 1,
   getAtlas: () => ({
     font: {

--- a/src/js/__mocks__/WebGLInstanceMock.ts
+++ b/src/js/__mocks__/WebGLInstanceMock.ts
@@ -61,6 +61,8 @@ const webgl = {
   boundUnits: [],
   bindTextureToUnit: () => {},
   addTexture: () => 1,
+  acquireTexture: () => true,
+  deleteTexture: () => {},
   getAtlas: () => ({
     font: {
       getTextureID: () => '1',

--- a/src/js/figure/DrawingObjects/GLObject/GLObject.test.ts
+++ b/src/js/figure/DrawingObjects/GLObject/GLObject.test.ts
@@ -84,14 +84,14 @@ describe('GLObject mask texture (textureMap)', () => {
     expect(placeholder.uniformName).toBe('u_mask1');
   });
 
-  test('registers base and mask on distinct texture units', () => {
+  test('registers base and mask as distinct textures', () => {
     expect(webgl.textures['base.png']).toBeDefined();
     expect(webgl.textures['mask.png']).toBeDefined();
-    expect(webgl.textures['base.png'].index)
-      .not.toEqual(webgl.textures['mask.png'].index);
+    expect(webgl.textures['base.png'].handle)
+      .not.toEqual(webgl.textures['mask.png'].handle);
   });
 
-  test('draw binds u_mask to the mask texture unit', () => {
+  test('draw binds base and mask to distinct content units', () => {
     const scene = new Scene();
     const identity = [
       1, 0, 0, 0,
@@ -99,10 +99,43 @@ describe('GLObject mask texture (textureMap)', () => {
       0, 0, 1, 0,
       0, 0, 0, 1,
     ];
+    gl.activeTexture.mockClear();
+    gl.bindTexture.mockClear();
     glObject.drawWithTransformMatrix(scene, identity, [1, 1, 1, 1], 3);
-    const maskIndex = webgl.textures['mask.png'].index;
-    const boundMask = gl.uniform1i.mock.calls.some(call => call[1] === maskIndex);
-    expect(boundMask).toBe(true);
+
+    // The draw binds the base and mask glTextures to the content pool.
+    const baseGl = webgl.textures['base.png'].glTexture;
+    const maskGl = webgl.textures['mask.png'].glTexture;
+    expect(gl.bindTexture.mock.calls.some(call => call[1] === baseGl)).toBe(true);
+    expect(gl.bindTexture.mock.calls.some(call => call[1] === maskGl)).toBe(true);
+
+    // Unit 0 is reserved for the target texture, so content starts at unit 1,
+    // and base and mask occupy different units within the same draw.
+    const baseUnit = webgl.boundUnits.indexOf('base.png');
+    const maskUnit = webgl.boundUnits.indexOf('mask.png');
+    expect(baseUnit).toBeGreaterThanOrEqual(1);
+    expect(maskUnit).toBeGreaterThanOrEqual(1);
+    expect(baseUnit).not.toEqual(maskUnit);
+  });
+
+  test('skips the draw when the base texture is missing instead of sampling a stale unit', () => {
+    const scene = new Scene();
+    const identity = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1,
+    ];
+    // Simulate a shared base texture being deleted by another element's cleanup
+    // while this element still references it.
+    webgl.deleteTexture('base.png');
+    gl.drawArrays.mockClear();
+    glObject.drawWithTransformMatrix(scene, identity, [1, 1, 1, 1], 3);
+
+    // Composed texture shaders sample u_texture unconditionally, so with no base
+    // texture to bind the object renders nothing rather than sampling whatever
+    // texture happens to occupy the content unit.
+    expect(gl.drawArrays).not.toHaveBeenCalled();
   });
 
   test('resetTextureBuffer deletes both textures from the registry', () => {

--- a/src/js/figure/DrawingObjects/GLObject/GLObject.test.ts
+++ b/src/js/figure/DrawingObjects/GLObject/GLObject.test.ts
@@ -138,6 +138,59 @@ describe('GLObject mask texture (textureMap)', () => {
     expect(gl.drawArrays).not.toHaveBeenCalled();
   });
 
+  test('consecutive draws of the same textures skip rebinding (bind-on-change)', () => {
+    const scene = new Scene();
+    const identity = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1,
+    ];
+    // First draw binds base and mask to their units.
+    glObject.drawWithTransformMatrix(scene, identity, [1, 1, 1, 1], 3);
+    gl.bindTexture.mockClear();
+    // Second draw: both textures are already on their units, so no rebinds.
+    glObject.drawWithTransformMatrix(scene, identity, [1, 1, 1, 1], 3);
+    const baseGl = webgl.textures['base.png'].glTexture;
+    const maskGl = webgl.textures['mask.png'].glTexture;
+    expect(gl.bindTexture.mock.calls.some(call => call[1] === baseGl)).toBe(false);
+    expect(gl.bindTexture.mock.calls.some(call => call[1] === maskGl)).toBe(false);
+  });
+
+  test('a draw rebinds the unit when a different texture has taken it', () => {
+    const scene = new Scene();
+    const identity = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1,
+    ];
+    glObject.drawWithTransformMatrix(scene, identity, [1, 1, 1, 1], 3);
+    // Something else takes unit 1 (the base texture's unit).
+    webgl.bindTextureToUnit('mask.png', 1);
+    gl.bindTexture.mockClear();
+    glObject.drawWithTransformMatrix(scene, identity, [1, 1, 1, 1], 3);
+    // The base texture must be re-bound since the cached unit no longer holds it.
+    const baseGl = webgl.textures['base.png'].glTexture;
+    expect(gl.bindTexture.mock.calls.some(call => call[1] === baseGl)).toBe(true);
+  });
+
+  test('adopting an unregistered texture id takes no reference and over-releases nothing', () => {
+    // initTexture acquired a reference to the base texture in beforeEach.
+    expect(glObject.acquiredBaseTextureId).toBe('base.png');
+    // Adopt an id that was never registered (simulates an atlas not uploaded yet).
+    glObject.setBaseTextureRef('not-registered');
+    // No reference was taken, so nothing is left dangling to over-release.
+    expect(glObject.acquiredBaseTextureId).toBeNull();
+
+    const deleteSpy = jest.spyOn(webgl, 'deleteTexture');
+    glObject.resetTextureBuffer(true);
+    // resetTextureBuffer releases only what was acquired — never the
+    // unregistered id (which would be an over-release without the hardening).
+    expect(deleteSpy.mock.calls.every(call => call[0] !== 'not-registered')).toBe(true);
+    deleteSpy.mockRestore();
+  });
+
   test('resetTextureBuffer deletes both textures from the registry', () => {
     glObject.resetTextureBuffer(true);
     expect(webgl.textures['base.png']).toBeUndefined();

--- a/src/js/figure/DrawingObjects/GLObject/GLObject.ts
+++ b/src/js/figure/DrawingObjects/GLObject/GLObject.ts
@@ -934,6 +934,9 @@ class GLObject extends DrawingObject {
     );
 
     const { texture } = this;
+    // Set when a textured object's base texture can't be bound, so we skip the
+    // draw rather than sampling a stale/wrong texture (see below).
+    let skipDraw = false;
     if (texture != null && targetTexture === false) {
       // Tell the position attribute how to get data out of positionBuffer (ARRAY_BUFFER)
       const texSize = 2;          // 2 components per iteration
@@ -950,28 +953,51 @@ class GLObject extends DrawingObject {
         locations.a_texcoord, texSize, texType,
         texNormalize, texStride, texOffset,
       );
-      gl.uniform1i(locations.u_use_texture, 1);
-      const { index } = webglInstance.textures[texture.id];
-      gl.uniform1i(locations.u_texture, index);
+      // Assign content texture units for this draw from the shared pool. Unit 0
+      // is reserved for the target/selector framebuffer texture, so content
+      // starts at unit 1: the base texture, then each mask texture in turn.
+      // bindTextureToUnit only issues a bindTexture when the unit isn't already
+      // pointing at that texture, so runs of draws sharing a texture (e.g. text
+      // sharing a font atlas) issue no bind calls.
+      let textureUnit = 1;
+      if (webglInstance.bindTextureToUnit(texture.id, textureUnit)) {
+        gl.uniform1i(locations.u_use_texture, 1);
+        gl.uniform1i(locations.u_texture, textureUnit);
+        textureUnit += 1;
 
-      // Bind the mask textures (textureMap color mode), each to its own texture
-      // unit and precomputed u_mask{i} sampler. They reuse the a_texcoord /
-      // v_texcoord bound above, so no extra attribute is needed. Uses an indexed
-      // loop with precomputed uniform names to avoid per-frame allocation.
-      const { maskTextures } = this;
-      for (let i = 0; i < maskTextures.length; i += 1) {
-        const maskTexture = maskTextures[i];
-        const maskLocation = locations[maskTexture.uniformName];
-        const maskRegistered = webglInstance.textures[maskTexture.id];
-        if (maskLocation != null && maskRegistered != null) {
-          gl.uniform1i(maskLocation, maskRegistered.index);
+        // Bind the mask textures (textureMap color mode), each to its own
+        // texture unit and precomputed u_mask{i} sampler. They reuse the
+        // a_texcoord / v_texcoord bound above, so no extra attribute is needed.
+        // Only assign the sampler if the bind succeeds — otherwise the uniform
+        // would default to sampler 0 (the reserved target texture) and recolor
+        // with garbage. Uses an indexed loop with precomputed uniform names to
+        // avoid per-frame allocation.
+        const { maskTextures } = this;
+        for (let i = 0; i < maskTextures.length; i += 1) {
+          const maskTexture = maskTextures[i];
+          const maskLocation = locations[maskTexture.uniformName];
+          if (maskLocation != null
+            && webglInstance.bindTextureToUnit(maskTexture.id, textureUnit)) {
+            gl.uniform1i(maskLocation, textureUnit);
+            textureUnit += 1;
+          }
         }
+      } else {
+        // The base texture isn't available (e.g. a shared texture was deleted by
+        // another element's cleanup while this one still references it). The
+        // composed texture shaders sample u_texture unconditionally, so there is
+        // no safe in-shader fallback — skip this object's draw this frame rather
+        // than sampling whatever stale texture occupies the unit.
+        gl.uniform1i(locations.u_use_texture, 0);
+        skipDraw = true;
       }
     } else {
       gl.uniform1i(locations.u_use_texture, 0);
     }
 
-    gl.drawArrays(this.glPrimitive, 0, numDrawVertices);
+    if (!skipDraw) {
+      gl.drawArrays(this.glPrimitive, 0, numDrawVertices);
+    }
 
     if (texture) {
       gl.disableVertexAttribArray(locations.a_texcoord);

--- a/src/js/figure/DrawingObjects/GLObject/GLObject.ts
+++ b/src/js/figure/DrawingObjects/GLObject/GLObject.ts
@@ -108,6 +108,11 @@ class GLObject extends DrawingObject {
   fragmentShader: TypeFragmentShader;
   selectorVertexShader: TypeVertexShader;
   selectorFragmentShader: TypeFragmentShader;
+  // The webgl texture id this object currently holds a base-texture reference to
+  // (acquired by initTexture, or adopted from a shared atlas via
+  // setBaseTextureRef). resetTextureBuffer releases exactly this id, so the
+  // release can never be unbalanced with the acquire. null = no reference held.
+  acquiredBaseTextureId!: string | null;
 
 
   constructor(
@@ -134,6 +139,7 @@ class GLObject extends DrawingObject {
     this.numVertices = 0;
     this.uniforms = {};
     this.texture = null;
+    this.acquiredBaseTextureId = null;
     this.maskTextures = [];
     // this.selectorProgramIndex = this.webgl.getProgram(selectorVertexShader, selectorFragShader);
     this.initProgram();
@@ -390,6 +396,10 @@ class GLObject extends DrawingObject {
     webgl.addTexture(
       id, (data || src) as any, loadColor, repeat, this.executeOnLoad.bind(this) as any, force,
     );
+    // addTexture took/holds a reference to this id; record it so
+    // resetTextureBuffer releases exactly what was acquired. (For a forced
+    // update the id is unchanged, so this is idempotent.)
+    this.acquiredBaseTextureId = id;
     this.state = webgl.textures[texture.id].state;
 
     // Register the optional mask textures (textureMap color mode). Each loads
@@ -455,6 +465,28 @@ class GLObject extends DrawingObject {
     //     this.state = 'loaded';
     //   }
     // }
+  }
+
+  /**
+   * Adopt a base-texture reference to an already-registered texture (e.g. a
+   * shared font atlas uploaded by the Atlas, whose id this object renders with
+   * but does not upload itself).
+   *
+   * Releases any previously-held base reference first (so a font/atlas change
+   * rebalances correctly) and is idempotent when the id is unchanged. If the
+   * texture isn't registered yet, no reference is taken and acquiredBaseTextureId
+   * is cleared, so the later resetTextureBuffer release stays balanced (it only
+   * releases a reference that was actually acquired).
+   */
+  setBaseTextureRef(id: string) {
+    if (this.acquiredBaseTextureId === id) {
+      return;
+    }
+    const { webgl } = this;
+    if (this.acquiredBaseTextureId != null) {
+      webgl.deleteTexture(this.acquiredBaseTextureId);
+    }
+    this.acquiredBaseTextureId = webgl.acquireTexture(id) ? id : null;
   }
 
   // A texture map is a texture coords point that lines up with the texture
@@ -623,14 +655,15 @@ class GLObject extends DrawingObject {
 
   resetTextureBuffer(deleteTexture: boolean = true) {
     const { texture, maskTextures, webgl, gl } = this;
-    if (texture) {
-      if (deleteTexture && webgl.textures[texture.id] != null) {
-        webgl.deleteTexture(texture.id);
-      }
-      if (texture.buffer != null) {
-        gl.deleteBuffer(texture.buffer);
-        texture.buffer = null;
-      }
+    if (deleteTexture && this.acquiredBaseTextureId != null) {
+      // Release exactly the base reference this object acquired, so a failed
+      // acquire (e.g. an atlas not registered yet) can never over-release.
+      webgl.deleteTexture(this.acquiredBaseTextureId);
+      this.acquiredBaseTextureId = null;
+    }
+    if (texture && texture.buffer != null) {
+      gl.deleteBuffer(texture.buffer);
+      texture.buffer = null;
     }
     if (deleteTexture) {
       maskTextures.forEach((maskTexture) => {

--- a/src/js/figure/FigurePrimitives/FigureElementPrimitiveGLText.ts
+++ b/src/js/figure/FigurePrimitives/FigureElementPrimitiveGLText.ts
@@ -121,11 +121,20 @@ export default class FigureElementPrimitiveGLText extends FigureElementPrimitive
       font: this.font,
     });
 
+    const textureID = this.atlas.font.getTextureID();
     if ((this.drawingObject as any).texture == null) {
-      (this.drawingObject as any).addTexture(this.atlas.font.getTextureID());
+      (this.drawingObject as any).addTexture(textureID);
     } else {
-      (this.drawingObject as any).texture.id = this.atlas.font.getTextureID();
+      (this.drawingObject as any).texture.id = textureID;
     }
+    // Take a webgl reference to the shared atlas texture so it survives other
+    // elements' cleanup. The Atlas registers/uploads the texture; this element
+    // only adopts its id (GLObject.addTexture above doesn't touch webgl), so
+    // without this its resetTextureBuffer release would be unbalanced and the
+    // first element's cleanup would free the atlas for the others.
+    // setBaseTextureRef releases any previously-held id (createAtlas re-runs on
+    // font changes) and is idempotent when the id is unchanged.
+    (this.drawingObject as any).setBaseTextureRef(textureID);
     // console.log(this.atlas)
     this.setText(this.text);
 

--- a/src/js/figure/FigurePrimitives/FigurePrimitives.glMask.test.ts
+++ b/src/js/figure/FigurePrimitives/FigurePrimitives.glMask.test.ts
@@ -84,7 +84,7 @@ describe('gl primitive mask recolor (textureMap)', () => {
     expect(e.drawingObject.texture.id).toBe('/base.png');
     expect(e.drawingObject.maskTextures.map(m => m.id)).toEqual(['/mask.png']);
     const { textures } = e.drawingObject.webgl;
-    expect(textures['/base.png'].index).not.toEqual(textures['/mask.png'].index);
+    expect(textures['/base.png'].handle).not.toEqual(textures['/mask.png'].handle);
   });
 
   test('seeds u_tint uniforms from the tints option', () => {
@@ -183,7 +183,7 @@ describe('gl primitive mask recolor (textureMap)', () => {
     // Two distinct mask textures registered on distinct units.
     expect(e.drawingObject.maskTextures.map(m => m.id)).toEqual(['/mask0.png', '/mask1.png']);
     const { textures } = e.drawingObject.webgl;
-    expect(textures['/mask0.png'].index).not.toEqual(textures['/mask1.png'].index);
+    expect(textures['/mask0.png'].handle).not.toEqual(textures['/mask1.png'].handle);
     // 8 tint uniforms exist; the 9th does not.
     expect(e.drawingObject.uniforms.u_tint7.value).toEqual([0, 0, 0, 0]); // null -> transparent
     expect(e.drawingObject.uniforms.u_tint4.value).toEqual([1, 0, 1, 1]);

--- a/src/js/figure/webgl/webgl.context.test.ts
+++ b/src/js/figure/webgl/webgl.context.test.ts
@@ -292,6 +292,37 @@ describe('WebGL context loss handling', () => {
       expect(atlas1).toBe(atlas2);
       expect(Object.keys(webgl.atlases)).toHaveLength(1);
     });
+
+    test('acquireTexture takes a reference; texture survives until all are released', () => {
+      webgl.addTexture('refs', [0, 0, 0, 0]);
+      expect(webgl.textures.refs.refCount).toBe(1);
+      // Two more owners adopt the already-registered texture.
+      expect(webgl.acquireTexture('refs')).toBe(true);
+      expect(webgl.acquireTexture('refs')).toBe(true);
+      expect(webgl.textures.refs.refCount).toBe(3);
+      // Releasing two of three keeps it alive...
+      webgl.deleteTexture('refs');
+      webgl.deleteTexture('refs');
+      expect(webgl.textures.refs).toBeDefined();
+      // ...releasing the last frees it.
+      webgl.deleteTexture('refs');
+      expect(webgl.textures.refs).toBeUndefined();
+    });
+
+    test('acquireTexture returns false and does nothing for an unregistered id', () => {
+      expect(webgl.acquireTexture('missing')).toBe(false);
+      expect(webgl.textures.missing).toBeUndefined();
+    });
+
+    test('deleteTexture past zero frees once and is a harmless no-op afterwards', () => {
+      webgl.addTexture('once', [0, 0, 0, 0]);
+      expect(webgl.textures.once.refCount).toBe(1);
+      webgl.deleteTexture('once');
+      expect(webgl.textures.once).toBeUndefined();
+      // An extra release must not throw or resurrect a negative count.
+      expect(() => webgl.deleteTexture('once')).not.toThrow();
+      expect(webgl.textures.once).toBeUndefined();
+    });
   });
 });
 
@@ -392,6 +423,135 @@ describe('Figure atlas integration', () => {
     ]);
 
     expect(Object.keys(figure.webglLow.atlases)).toHaveLength(1);
+  });
+  test('removing one of two text elements sharing an atlas keeps the atlas alive', () => {
+    const figure = new Figure({ htmlId: 'c', color: [1, 0, 0, 1] });
+
+    figure.add([
+      {
+        name: 'text1',
+        make: 'text',
+        text: 'hello',
+        font: { size: 0.2, render: 'gl', atlasId: 'shared' },
+      },
+      {
+        name: 'text2',
+        make: 'text',
+        text: 'world',
+        font: { size: 0.5, render: 'gl', atlasId: 'shared' },
+      },
+    ]);
+
+    // The Atlas plus both text elements hold references to the shared texture.
+    expect(figure.webglLow.textures.shared).toBeDefined();
+    expect(figure.webglLow.textures.shared.refCount).toBeGreaterThan(1);
+
+    // Removing one text element releases its reference, but the shared atlas the
+    // other element still uses must NOT be freed (the refcount fix). Before
+    // refcounting, the first cleanup deleted the atlas out from under text2.
+    figure.elements.remove('text1');
+    expect(figure.webglLow.textures.shared).toBeDefined();
+  });
+  test('detach-then-remove workaround (texture=null before remove) stays refcount-balanced', () => {
+    // Replicates a downstream consumer's pre-refcount workaround: before
+    // removing an element it calls resetBuffers(false) and nulls the texture
+    // ref so the old cleanup path could not delete the shared atlas. The release
+    // is now keyed on acquiredBaseTextureId (not texture.id), so nulling texture
+    // must NOT skip the decrement: the count stays balanced (no leak) and the
+    // atlas survives for the sibling element.
+    const figure = new Figure({ htmlId: 'c', color: [1, 0, 0, 1] });
+    figure.add([
+      {
+        name: 'text1',
+        make: 'text',
+        text: 'hello',
+        font: { size: 0.2, render: 'gl', atlasId: 'shared' },
+      },
+      {
+        name: 'text2',
+        make: 'text',
+        text: 'world',
+        font: { size: 0.5, render: 'gl', atlasId: 'shared' },
+      },
+    ]);
+    const refBefore = figure.webglLow.textures.shared.refCount;
+
+    const element = figure.getElement('text1');
+    element.drawingObject.resetBuffers(false);
+    element.drawingObject.texture = null;
+    figure.elements.remove('text1');
+
+    // The decrement still happened (exactly once) despite texture=null, and the
+    // atlas the sibling still uses is alive.
+    expect(figure.webglLow.textures.shared).toBeDefined();
+    expect(figure.webglLow.textures.shared.refCount).toBe(refBefore - 1);
+  });
+  test('removing both shared-atlas text elements leaves the texture held by its Atlas', () => {
+    const figure = new Figure({ htmlId: 'c', color: [1, 0, 0, 1] });
+
+    figure.add([
+      {
+        name: 'text1',
+        make: 'text',
+        text: 'hello',
+        font: { size: 0.2, render: 'gl', atlasId: 'shared' },
+      },
+      {
+        name: 'text2',
+        make: 'text',
+        text: 'world',
+        font: { size: 0.5, render: 'gl', atlasId: 'shared' },
+      },
+    ]);
+
+    const refBefore = figure.webglLow.textures.shared.refCount;
+    figure.elements.remove('text1');
+    figure.elements.remove('text2');
+
+    // Both text references are released (count drops by exactly two), and the
+    // Atlas's own residual reference keeps the texture alive until teardown.
+    expect(figure.webglLow.textures.shared.refCount).toBe(refBefore - 2);
+    expect(figure.webglLow.textures.shared).toBeDefined();
+  });
+  test('changing a text element font moves its atlas reference to the new atlas', () => {
+    const figure = new Figure({ htmlId: 'c', color: [1, 0, 0, 1] });
+    figure.add([{
+      name: 'text1',
+      make: 'text',
+      text: 'hello',
+      font: { size: 0.2, render: 'gl', atlasId: 'a' },
+    }]);
+    const element = figure.getElement('text1');
+
+    expect(figure.webglLow.textures.a).toBeDefined();
+    const aRefBefore = figure.webglLow.textures.a.refCount;
+    expect(aRefBefore).toBeGreaterThan(1); // Atlas + this element
+
+    // Change the font so the element adopts a different atlas.
+    element.setText({ font: { atlasId: 'b' } });
+
+    // The old atlas keeps the Atlas's own reference (not freed), but the
+    // element's reference has moved to the new atlas.
+    expect(figure.webglLow.textures.a).toBeDefined();
+    expect(figure.webglLow.textures.a.refCount).toBe(aRefBefore - 1);
+    expect(figure.webglLow.textures.b).toBeDefined();
+    expect(figure.webglLow.textures.b.refCount).toBeGreaterThan(1);
+  });
+  test('re-adopting the same atlas id does not double-acquire (idempotent)', () => {
+    const figure = new Figure({ htmlId: 'c', color: [1, 0, 0, 1] });
+    figure.add([{
+      name: 'text1',
+      make: 'text',
+      text: 'hello',
+      font: { size: 0.2, render: 'gl', atlasId: 'a' },
+    }]);
+    const element = figure.getElement('text1');
+    const refBefore = figure.webglLow.textures.a.refCount;
+
+    // Re-run createAtlas with the same atlas id (font unchanged in id terms).
+    element.setText({ font: { atlasId: 'a' } });
+
+    expect(figure.webglLow.textures.a.refCount).toBe(refBefore);
   });
   test('two gl text elements with different sizes DO NOT share one atlas', () => {
     const figure = new Figure({ htmlId: 'c', color: [1, 0, 0, 1] });

--- a/src/js/figure/webgl/webgl.ts
+++ b/src/js/figure/webgl/webgl.ts
@@ -235,6 +235,10 @@ class WebGLInstance {
       // Stable, monotonic id for the texture. NOT a texture unit number — units
       // are assigned per draw from a small shared pool (see bindTextureToUnit).
       handle: number;
+      // Number of live owners referencing this id (e.g. several GLText elements
+      // sharing one font atlas, plus the Atlas itself). The GL texture is freed
+      // only when this reaches zero — see addTexture/deleteTexture.
+      refCount: number;
       state: 'loading' | 'loaded';
       onLoad: Array<((b: boolean, n: number) => void) | string>;
     };
@@ -299,47 +303,53 @@ class WebGLInstance {
     force: boolean = false,
   ) {
     /*
-      If the texture already exits, then return its index. If the texture is
-      still loading, then add the onLoad callback to the list of callbacks to
-      be called once the texture loads.
+      A texture id can be shared by multiple owners (e.g. several GLText elements
+      using the same font atlas, plus the Atlas itself). Each addTexture call
+      that isn't a forced content update acquires one reference; deleteTexture
+      releases one, and the GL texture is freed only when the last owner releases
+      it. This lets one element's cleanup() drop its reference without pulling a
+      still-shared texture out from under the survivors.
+
+      If the texture already exists and is still loading, the onLoad callback is
+      added to the list to be called once the texture loads.
     */
     if (!force && this.textures[id] != null) {
-      if (this.textures[id].state === 'loaded') {
-        if (onLoad != null) {
-          this.textures[id].onLoad.push(onLoad);
-        }
-        this.onLoad(id);
-        return this.textures[id].handle;
+      // Another owner (or the same owner re-acquiring) references an existing
+      // texture: take a reference and (re)register the load callback.
+      const existingTexture = this.textures[id];
+      existingTexture.refCount += 1;
+      if (onLoad != null) {
+        existingTexture.onLoad.push(onLoad);
       }
-      // Otherwise loading
+      if (existingTexture.state === 'loaded') {
+        this.onLoad(id);
+      }
+      return existingTexture.handle;
+    }
+    const { gl } = this;
+    if (this.textures[id] != null) {
+      // Forced content update of an existing texture: keep its identity AND
+      // reference count so other owners survive the update. setTextureData
+      // (below) frees and replaces the old glTexture, so the entry — including
+      // its glTexture pointer — is preserved here rather than recreated.
+      // Append (don't replace) onLoad so pending callbacks other owners
+      // registered while the texture was still loading aren't silently dropped.
+      this.textures[id].state = 'loading';
       if (onLoad != null) {
         this.textures[id].onLoad.push(onLoad);
       }
-      return this.textures[id].handle;;
-    }
-    // Reuse the existing handle when replacing a texture (e.g. force update), so
-    // its identity is stable; otherwise allocate a fresh monotonic handle.
-    let handle;
-    if (this.textures[id] != null) {
-      handle = this.textures[id].handle;
     } else {
-      handle = this.nextTextureHandle;
+      // Brand new texture: the first owner holds the only reference.
+      this.textures[id] = {
+        id,
+        state: 'loading',
+        onLoad: onLoad != null ? [onLoad] : [],
+        handle: this.nextTextureHandle,
+        refCount: 1,
+      } as any;
       this.nextTextureHandle += 1;
     }
-    // If a texture already exists, then unload it
-    this.deleteTexture(id);
-    const { gl } = this;
-
-    this.textures[id] = {
-      id,
-      state: 'loading',
-      onLoad: [],
-      handle,
-    } as any;
     const texture = this.textures[id];
-    if (onLoad != null) {
-      texture.onLoad.push(onLoad);
-    }
     // If the data is a url string, then load the data into an image
     if (typeof data === 'string') {
       this.setTextureData(id, loadColor);
@@ -393,15 +403,45 @@ class WebGLInstance {
     }
   }
 
+  // Take an additional reference to an already-registered texture, without
+  // re-uploading it or touching its load callbacks. Used when an element adopts
+  // a texture another owner created and uploaded (e.g. a GLText element sharing
+  // a font atlas registered by the Atlas). Returns false if the texture isn't
+  // registered yet, in which case no reference was taken. Release with
+  // deleteTexture.
+  acquireTexture(id: string): boolean {
+    const texture = this.textures[id];
+    if (texture == null) {
+      return false;
+    }
+    texture.refCount += 1;
+    return true;
+  }
+
+  // Release one reference to a texture. The GL texture is freed only once the
+  // last owner releases it, so one element's cleanup can't delete a texture
+  // another element still shares (see addTexture for the rationale).
   deleteTexture(id: string) {
     const texture = this.textures[id];
     if (texture == null) {
       return;
     }
-    const { gl } = this;
+    texture.refCount -= 1;
+    if (texture.refCount <= 0) {
+      this.freeTexture(id);
+    }
+  }
 
-    // If texture exists, then delete it. gl.deleteTexture unbinds it from any
-    // unit it was bound to, so we just drop the stale cache entries.
+  // Unconditionally free a texture regardless of reference count. Used for
+  // teardown (cleanup), where every owner is going away at once.
+  freeTexture(id: string) {
+    const texture = this.textures[id];
+    if (texture == null) {
+      return;
+    }
+    const { gl } = this;
+    // gl.deleteTexture unbinds it from any unit it was bound to, so we just drop
+    // the stale cache entries.
     if (texture.glTexture != null) {
       gl.deleteTexture(texture.glTexture);
       this.clearBoundUnits(id);
@@ -473,9 +513,10 @@ class WebGLInstance {
       }
     });
     this.programs = [];
-    // Delete all textures
+    // Free all textures outright, ignoring reference counts — every owner is
+    // going away in this teardown.
     Object.keys(this.textures).forEach((id) => {
-      this.deleteTexture(id);
+      this.freeTexture(id);
     });
     this.textures = {};
     // Clean up atlases

--- a/src/js/figure/webgl/webgl.ts
+++ b/src/js/figure/webgl/webgl.ts
@@ -2,7 +2,7 @@
 import getShaders from './shaders';
 import type { TypeFragmentShader, TypeVertexShader } from './shaders';
 import TargetTexture from './target';
-import { hash32 } from '../../tools/tools';
+import { hash32, Console } from '../../tools/tools';
 import FontManager from '../FontManager';
 import { FunctionMap } from '../../tools/FunctionMap';
 import { colorToInt } from '../../tools/color';
@@ -232,11 +232,28 @@ class WebGLInstance {
   textures!: {
     [name: string]: {
       glTexture: WebGLTexture;
-      index: number;
+      // Stable, monotonic id for the texture. NOT a texture unit number — units
+      // are assigned per draw from a small shared pool (see bindTextureToUnit).
+      handle: number;
       state: 'loading' | 'loaded';
       onLoad: Array<((b: boolean, n: number) => void) | string>;
     };
   };
+
+  // Content texture units are a small shared pool reused across draws. Unit 0 is
+  // reserved for the target/selector framebuffer texture, so content starts at
+  // unit 1. boundUnits[u] tracks which texture id is currently bound to GL unit
+  // u, so bindTextureToUnit can skip redundant binds (bind-on-change).
+  boundUnits!: Array<string | null>;
+  // Monotonic source for texture handles (never reused, so deleting a texture
+  // can never cause a later texture to collide with a live one).
+  nextTextureHandle!: number;
+  // gl.MAX_TEXTURE_IMAGE_UNITS (the fragment-shader sampler limit), queried once
+  // for a diagnostic warning. Matches the per-object mask guard in
+  // FigurePrimitives.gl().
+  maxTextureUnits!: number;
+  // Set once the unit-budget warning has fired, so it isn't logged every frame.
+  warnedUnitOverflow!: boolean;
 
   atlases: {
     [atlasId: string]: Atlas;
@@ -292,19 +309,22 @@ class WebGLInstance {
           this.textures[id].onLoad.push(onLoad);
         }
         this.onLoad(id);
-        return this.textures[id].index;
+        return this.textures[id].handle;
       }
       // Otherwise loading
       if (onLoad != null) {
         this.textures[id].onLoad.push(onLoad);
       }
-      return this.textures[id].index;;
+      return this.textures[id].handle;;
     }
-    let index = 0;
+    // Reuse the existing handle when replacing a texture (e.g. force update), so
+    // its identity is stable; otherwise allocate a fresh monotonic handle.
+    let handle;
     if (this.textures[id] != null) {
-      index = this.textures[id].index;
+      handle = this.textures[id].handle;
     } else {
-      index = Object.keys(this.textures).length + 1;
+      handle = this.nextTextureHandle;
+      this.nextTextureHandle += 1;
     }
     // If a texture already exists, then unload it
     this.deleteTexture(id);
@@ -314,7 +334,7 @@ class WebGLInstance {
       id,
       state: 'loading',
       onLoad: [],
-      index,
+      handle,
     } as any;
     const texture = this.textures[id];
     if (onLoad != null) {
@@ -339,7 +359,7 @@ class WebGLInstance {
       this.onLoad(id);
       texture.state = 'loaded';
     }
-    return this.textures[id].index;
+    return this.textures[id].handle;
   }
 
   getAtlas(options: OBJ_Atlas) {
@@ -380,11 +400,11 @@ class WebGLInstance {
     }
     const { gl } = this;
 
-    // If texture exists, then delete it
+    // If texture exists, then delete it. gl.deleteTexture unbinds it from any
+    // unit it was bound to, so we just drop the stale cache entries.
     if (texture.glTexture != null) {
-      gl.activeTexture(gl.TEXTURE0 + texture.index);
-      gl.bindTexture(gl.TEXTURE_2D, null);
       gl.deleteTexture(texture.glTexture);
+      this.clearBoundUnits(id);
     }
     this.cancel(id);
     delete this.textures[id];
@@ -394,6 +414,54 @@ class WebGLInstance {
     Object.keys(this.textures).forEach((id) => {
       this.textures[id].glTexture = null as any;
     });
+    // The new context starts with nothing bound, so the bind cache is stale.
+    this.boundUnits = [];
+  }
+
+  // Drop any working-unit cache entries that point at this texture id, so a
+  // future draw re-binds rather than trusting a stale/deleted glTexture.
+  clearBoundUnits(id: string) {
+    for (let u = 0; u < this.boundUnits.length; u += 1) {
+      if (this.boundUnits[u] === id) {
+        this.boundUnits[u] = null;
+      }
+    }
+  }
+
+  /*
+    Bind a registered texture to a content texture unit for the current draw.
+
+    Content units are a small shared pool (unit 0 is reserved for the
+    target/selector framebuffer texture). bindTexture is only issued when the
+    unit is not already pointing at this texture, so runs of draws that share a
+    texture (e.g. text sharing a font atlas) issue zero bind calls.
+  */
+  bindTextureToUnit(id: string, unit: number): boolean {
+    const texture = this.textures[id];
+    if (texture == null || texture.glTexture == null) {
+      return false;
+    }
+    if (unit >= this.maxTextureUnits) {
+      // Out of unit budget: warn once (not every frame) and don't issue an
+      // out-of-range bind. The caller treats false as "not bound".
+      if (!this.warnedUnitOverflow) {
+        Console(
+          `FigureOne WebGL warning: texture unit ${unit} exceeds this device's `
+          + `MAX_TEXTURE_IMAGE_UNITS (${this.maxTextureUnits}). Reduce the `
+          + 'number of simultaneous textures/masks.',
+        );
+        this.warnedUnitOverflow = true;
+      }
+      return false;
+    }
+    if (this.boundUnits[unit] === id) {
+      return true;
+    }
+    const { gl } = this;
+    gl.activeTexture(gl.TEXTURE0 + unit);
+    gl.bindTexture(gl.TEXTURE_2D, texture.glTexture);
+    this.boundUnits[unit] = id;
+    return true;
   }
 
   cleanup() {
@@ -431,20 +499,27 @@ class WebGLInstance {
     }
 
     const texture = this.textures[id];
-    const { index } = texture;
     const { gl } = this;
+    // Upload happens on the first content unit as scratch. Any cache entry for
+    // this id refers to the old glTexture we're about to replace, so invalidate
+    // them all before binding the new one.
+    const uploadUnit = 1;
+    this.clearBoundUnits(id);
 
     // If texture exists, then delete it
     if (texture.glTexture != null) {
-      gl.activeTexture(gl.TEXTURE0 + index);
+      gl.activeTexture(gl.TEXTURE0 + uploadUnit);
       gl.bindTexture(gl.TEXTURE_2D, null);
       gl.deleteTexture(texture.glTexture);
     }
     // Create a texture
     const glTexture = gl.createTexture();
     texture.glTexture = glTexture;
-    gl.activeTexture(gl.TEXTURE0 + index);
+    gl.activeTexture(gl.TEXTURE0 + uploadUnit);
     gl.bindTexture(gl.TEXTURE_2D, glTexture);
+    // The new glTexture is now bound to the upload unit; record it so a draw
+    // that needs it on this unit can skip a redundant bind.
+    this.boundUnits[uploadUnit] = id;
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 1);
 
     // If image is a color, then create s ingle pixel image of that color
@@ -511,12 +586,12 @@ class WebGLInstance {
   // }
 
   onLoad(id: string) {
-    this.textures[id].onLoad.forEach(f => this.fnMap.exec(f, true, this.textures[id].index));
+    this.textures[id].onLoad.forEach(f => this.fnMap.exec(f, true, this.textures[id].handle));
     this.textures[id].onLoad = [];
   }
 
   cancel(id: string) {
-    this.textures[id].onLoad.forEach(f => this.fnMap.exec(f, false, this.textures[id].index));
+    this.textures[id].onLoad.forEach(f => this.fnMap.exec(f, false, this.textures[id].handle));
     this.textures[id].onLoad = [];
   }
 
@@ -619,6 +694,13 @@ class WebGLInstance {
   init(gl: WebGLRenderingContext) {
     this.gl = gl;
     this.textures = {};
+    this.boundUnits = [];
+    this.nextTextureHandle = 1;
+    this.warnedUnitOverflow = false;
+    const maxUnits = gl.getParameter
+      ? gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS)
+      : 0;
+    this.maxTextureUnits = maxUnits || 8;
     this.programs = [];
     this.targetTexture = null;
     this.lastUsedProgram = null;

--- a/src/tests/primitives/line/__snapshots__/line.test.ts.snap
+++ b/src/tests/primitives/line/__snapshots__/line.test.ts.snap
@@ -200,6 +200,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -305,9 +306,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -996,6 +999,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -1197,9 +1201,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -1924,6 +1930,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -2197,9 +2204,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -3236,6 +3245,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -4157,9 +4167,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -4908,6 +4920,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -5229,9 +5242,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -6268,6 +6283,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -7189,9 +7205,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -7904,6 +7922,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -8153,9 +8172,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -8832,6 +8853,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -9009,9 +9031,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -9623,6 +9647,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -9728,9 +9753,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -10382,6 +10409,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -10487,9 +10515,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -11156,6 +11186,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -11261,9 +11292,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -11848,6 +11881,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -11953,9 +11987,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -12540,6 +12576,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -12645,9 +12682,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -13232,6 +13271,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -13337,9 +13377,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -13927,6 +13969,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -14128,9 +14171,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -14718,6 +14763,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -14919,9 +14965,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -15510,6 +15558,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -15711,9 +15760,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -16301,6 +16352,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -16502,9 +16554,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -17092,6 +17146,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -17293,9 +17348,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -17880,6 +17937,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -17985,9 +18043,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -18572,6 +18632,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -18677,9 +18738,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -19264,6 +19327,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -19369,9 +19433,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -19973,6 +20039,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -20078,9 +20145,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -20665,6 +20734,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -20770,9 +20840,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -21374,6 +21446,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -21479,9 +21552,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -22066,6 +22141,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -22171,9 +22247,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -22830,6 +22908,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -23023,9 +23102,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -23610,6 +23691,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -23731,9 +23813,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -24318,6 +24402,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -24423,9 +24508,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -25010,6 +25097,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -25115,9 +25203,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -25721,6 +25811,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -25826,9 +25917,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -26475,6 +26568,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -26580,9 +26674,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -27208,6 +27304,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -27313,9 +27410,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -27927,6 +28026,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -28032,9 +28132,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -28646,6 +28748,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -28751,9 +28854,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -29338,6 +29443,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -29443,9 +29549,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -30030,6 +30138,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -30135,9 +30244,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -30722,6 +30833,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -30827,9 +30939,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -31414,6 +31528,7 @@ FigureElementPrimitive {
   "drawPriority": 1,
   "drawTransforms": [],
   "drawingObject": GLObject {
+    "acquiredBaseTextureId": null,
     "attributes": {
       "a_vertex": {
         "buffer": undefined,
@@ -31519,9 +31634,11 @@ FigureElementPrimitive {
       "dimension": 2,
     },
     "webgl": {
+      "acquireTexture": [Function],
       "addTexture": [Function],
       "bindTextureToUnit": [Function],
       "boundUnits": [],
+      "deleteTexture": [Function],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {

--- a/src/tests/primitives/line/__snapshots__/line.test.ts.snap
+++ b/src/tests/primitives/line/__snapshots__/line.test.ts.snap
@@ -306,6 +306,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -362,7 +364,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -1196,6 +1198,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -1252,7 +1256,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -2194,6 +2198,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -2250,7 +2256,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -4152,6 +4158,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -4208,7 +4216,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -5222,6 +5230,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -5278,7 +5288,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -7180,6 +7190,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -7236,7 +7248,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -8142,6 +8154,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -8198,7 +8212,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -8996,6 +9010,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -9052,7 +9068,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -9713,6 +9729,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -9769,7 +9787,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -10470,6 +10488,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -10526,7 +10546,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -11242,6 +11262,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -11298,7 +11320,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -11932,6 +11954,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -11988,7 +12012,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -12622,6 +12646,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -12678,7 +12704,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -13312,6 +13338,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -13368,7 +13396,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -14101,6 +14129,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -14157,7 +14187,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -14890,6 +14920,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -14946,7 +14978,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -15680,6 +15712,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -15736,7 +15770,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -16469,6 +16503,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -16525,7 +16561,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -17258,6 +17294,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -17314,7 +17352,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -17948,6 +17986,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -18004,7 +18044,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -18638,6 +18678,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -18694,7 +18736,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -19328,6 +19370,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -19384,7 +19428,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -20035,6 +20079,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -20091,7 +20137,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -20725,6 +20771,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -20781,7 +20829,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -21432,6 +21480,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -21488,7 +21538,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -22122,6 +22172,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -22178,7 +22230,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -22972,6 +23024,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -23028,7 +23082,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -23678,6 +23732,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -23734,7 +23790,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -24368,6 +24424,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -24424,7 +24482,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -25058,6 +25116,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -25114,7 +25174,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -25767,6 +25827,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -25823,7 +25885,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -26519,6 +26581,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -26575,7 +26639,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -27250,6 +27314,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -27306,7 +27372,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -27967,6 +28033,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -28023,7 +28091,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -28684,6 +28752,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -28740,7 +28810,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -29374,6 +29444,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -29430,7 +29502,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -30064,6 +30136,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -30120,7 +30194,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -30754,6 +30828,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -30810,7 +30886,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],
@@ -31444,6 +31520,8 @@ FigureElementPrimitive {
     },
     "webgl": {
       "addTexture": [Function],
+      "bindTextureToUnit": [Function],
+      "boundUnits": [],
       "getAtlas": [Function],
       "getProgram": [Function],
       "gl": {
@@ -31500,7 +31578,7 @@ FigureElementPrimitive {
       },
       "textures": {
         "1": {
-          "index": 1,
+          "handle": 1,
         },
       },
       "useProgram": [Function],


### PR DESCRIPTION
## Summary
- Assign WebGL texture units per draw from a small shared pool (with bind-on-change) instead of one permanent unit per texture, removing the silent cap on the number of distinct live textures.
- Reference-count textures including font atlases, so removing one element no longer frees a shared atlas out from under others still using it; plus safe-skip on missing textures, a unit-budget diagnostic, and balanced acquire/release.
- Add tests (shared-atlas teardown, bind-on-change, font-change rebalancing, over-release safety) and an upgrade guide (TEXTURE_ATLAS_UPGRADE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)