### PR TITLE
Make textureMap mask alpha channel a usable 4th tint region

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -119,11 +119,15 @@ Then ask the user:
 
 The summary should be 1-3 bullet points describing what changed, written from a user/consumer perspective (not implementation details).
 
+5. **Update the LLM docs if the PR changes the public API.** Edit the canonical root files `llms.txt` and `llms-full.txt` (NOT the `package/` copies — `build.sh` regenerates those from root via `cp`). They are hand-maintained, so new or changed user-facing API is missing unless updated here. Determine from the Phase 3 diff whether the PR adds, removes, or changes any public surface — e.g. a new primitive/collection, new option-object properties (`OBJ_`/`COL_`/`EQN_` types), new methods, renamed/removed options, or changed defaults.
+   - If **no** public API changed, skip this step and note "LLM docs: no API change" in the Phase 5 summary.
+   - If public API **did** change, update both `llms.txt` (concise overview — add a short example or property only if it belongs at that level) and `llms-full.txt` (comprehensive reference — add/edit the relevant property tables, type sections, and examples). Match each file's existing structure and tone, and mirror the source JSDoc (e.g. `FigurePrimitiveTypes.ts`) so the docs and types agree.
+
 ---
 
 ### Phase 7: Commit, push, and merge
 
-1. Stage the changes: `git add package.json docs/changelog.md`
+1. Stage the changes: `git add package.json docs/changelog.md` (also `git add llms.txt llms-full.txt` if they were updated in Phase 6)
 2. Commit with message: `Release vX.Y.Z`
 3. Push: `git push origin <branch>`
 4. Merge the PR: `gh pr merge <number> --merge --delete-branch`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Releases
 
+## 1.9.1
+* Fix the `textureMap` color mode so a mask's alpha channel works as an independent fourth region instead of bleeding its tint across every painted region; paint the fourth region as opaque black (`[0, 0, 0, 1]`), regions 0-2 as red/green/blue, and leave keep-base areas transparent
+
 ## 1.9.0
 * WebGL textures, including shared font atlases, are now reference-counted, so removing one element that shares a font atlas no longer deletes the atlas out from under other elements still using it
 * Texture units are assigned per draw from a small shared pool instead of one permanent unit per texture, removing a silent cap on the number of distinct textures that could render at once; a missing or not-yet-loaded texture now skips its draw rather than rendering incorrectly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/webgl/shaders.test.ts
+++ b/src/js/figure/webgl/shaders.test.ts
@@ -32,7 +32,9 @@ describe('Shaders', () => {
       expect(shaders.fragmentSource).toContain('mix(col, u_tint0.rgb, mask0.r * u_tint0.a)');
       expect(shaders.fragmentSource).toContain('mix(col, u_tint1.rgb, mask0.g * u_tint1.a)');
       expect(shaders.fragmentSource).toContain('mix(col, u_tint2.rgb, mask0.b * u_tint2.a)');
-      expect(shaders.fragmentSource).toContain('mix(col, u_tint3.rgb, mask0.a * u_tint3.a)');
+      // The alpha channel is gated on (1 - r - g - b) so region 3 is only the
+      // opaque-black pixels not already claimed by an r/g/b region.
+      expect(shaders.fragmentSource).toContain('mix(col, u_tint3.rgb, mask0.a * (1.0 - clamp(mask0.r + mask0.g + mask0.b, 0.0, 1.0)) * u_tint3.a)');
     });
     test('vars include the texture, mask and tint uniforms', () => {
       expect(shaders.vars).toEqual(expect.arrayContaining([
@@ -65,7 +67,7 @@ describe('Shaders', () => {
       // mask 2 (the third) uses tints 8..11.
       expect(shaders.fragmentSource).toContain('texture2D(u_mask2, v_texcoord)');
       expect(shaders.fragmentSource).toContain('mix(col, u_tint8.rgb, mask2.r * u_tint8.a)');
-      expect(shaders.fragmentSource).toContain('mix(col, u_tint11.rgb, mask2.a * u_tint11.a)');
+      expect(shaders.fragmentSource).toContain('mix(col, u_tint11.rgb, mask2.a * (1.0 - clamp(mask2.r + mask2.g + mask2.b, 0.0, 1.0)) * u_tint11.a)');
     });
     test('vars include every mask and tint uniform', () => {
       expect(shaders.vars).toEqual(expect.arrayContaining([

--- a/src/js/figure/webgl/shaders.ts
+++ b/src/js/figure/webgl/shaders.ts
@@ -329,13 +329,31 @@ function composeFragShader(
     // alpha controls how strongly that region is recolored (0 = leave the base
     // color unchanged). With one mask this is exactly four mixes and one extra
     // texture fetch; each additional mask adds one fetch and four mixes.
+    //
+    // Masks are uploaded with premultiplied alpha, so a region only carries full
+    // weight where the mask pixel is opaque. Author each mask pixel as one of:
+    //   keep base : [0, 0, 0, 0] (transparent)
+    //   region 0  : [1, 0, 0, 1] -> u_tint0   (r channel)
+    //   region 1  : [0, 1, 0, 1] -> u_tint1   (g channel)
+    //   region 2  : [0, 0, 1, 1] -> u_tint2   (b channel)
+    //   region 3  : [0, 0, 0, 1] -> u_tint3   (a channel, opaque black)
+    // With every painted region opaque, the alpha channel is 1 across all of them,
+    // so it can't act as an independent region on its own. The a-channel mix below
+    // gates on (1 - r - g - b) so region 3 is exactly the opaque-black pixels - the
+    // ones not already claimed by an r/g/b region. Regions 0-2 support partial
+    // weight by lowering their channel value (e.g. [0.5, 0, 0, 1]); region 3 is
+    // full-weight only, with slight antialiasing softness at its borders.
     src += '  vec4 base = texture2D(u_texture, v_texcoord);\n';
     src += '  vec3 col = base.rgb;\n';
     for (let m = 0; m < numMasks; m += 1) {
       src += `  vec4 mask${m} = texture2D(u_mask${m}, v_texcoord);\n`;
       for (let c = 0; c < CHANNELS_PER_MASK; c += 1) {
         const t = m * CHANNELS_PER_MASK + c;
-        src += `  col = mix(col, u_tint${t}.rgb, mask${m}.${channels[c]} * u_tint${t}.a);\n`;
+        if (channels[c] === 'a') {
+          src += `  col = mix(col, u_tint${t}.rgb, mask${m}.a * (1.0 - clamp(mask${m}.r + mask${m}.g + mask${m}.b, 0.0, 1.0)) * u_tint${t}.a);\n`;
+        } else {
+          src += `  col = mix(col, u_tint${t}.rgb, mask${m}.${channels[c]} * u_tint${t}.a);\n`;
+        }
       }
     }
     src += '  gl_FragColor = vec4(col, base.a * u_color.a);\n';


### PR DESCRIPTION
## Summary
- Gate the textureMap mask's alpha-channel mix on `(1 - r - g - b)` so region 3 (opaque-black pixels) becomes an independent tint region instead of bleeding across every opaque region under premultiplied alpha.
- Document the four-region authoring convention (keep-base `[0,0,0,0]`; regions 0-2 via r/g/b; region 3 via opaque black `[0,0,0,1]`).
- Update shader tests to assert the gated alpha mix for single- and multi-mask cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)