### PR TITLE
Fix isFormIgnored leaking for elements nested in a form collection

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Releases
 
+## 1.10.1
+* Fix `isFormIgnored` not protecting an element nested inside a `FigureElementCollection` that is itself a form element. Previously, showing the form revealed every descendant via `showAll` and recolored them via the default colour cascade, overriding the flag. Form-driven shows (immediate and dissolve-in) now skip form-ignored descendant subtrees, and the form colour cascade (immediate, animated `move`, and `setElementColors`) carries `'form'` provenance so it skips form-ignored descendants too — a flagged child keeps its visibility and colour even when its parent collection is shown or recoloured by a form
+
 ## 1.10.0
 * Add a `rotateControl` primitive that rotates a 3D element with touch/drag gestures — the same on-screen motion as `cameraControl`, but the object turns while the camera and world-fixed lights stay put, so its faces are shaded differently as it rotates
 * Set `controlElement` to the element to rotate (required; it must not be an ancestor of the control)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figureone",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Draw, animate and interact with shapes, text, plots and equations in Javascript. Create interactive slide shows, and interactive videos.",
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/src/js/figure/Animation/AnimationStep/ElementAnimationStep/ColorAnimationStep.ts
+++ b/src/js/figure/Animation/AnimationStep/ElementAnimationStep/ColorAnimationStep.ts
@@ -28,6 +28,7 @@ export type OBJ_ColorAnimationStep = {
   target?: TypeColor | 'dim' | 'undim';     // Either target or delta must be defined
   delta?: TypeColor;      // delta overrides target if both are defined
   dissolve?: 'in' | 'out' | null;
+  setColorFrom?: string | null;  // provenance passed to setColor (e.g. 'form')
 } & OBJ_ElementAnimationStep;
 
 const addColors = (color1: TypeColor, color2: TypeColor) => color1.map((c: number, index: number) => Math.min(c + color2[index], 1));
@@ -105,6 +106,7 @@ export class ColorAnimationStep extends ElementAnimationStep {
     whenComplete: TypeColor;  // Color after dissolving
     dissolve?: 'in' | 'out' | null;
     setDefault?: boolean;
+    setColorFrom?: string | null;
   };
 
   /**
@@ -114,7 +116,7 @@ export class ColorAnimationStep extends ElementAnimationStep {
     const ElementAnimationStepOptionsIn =
       joinObjects<any>({}, ...options, { type: 'color' });
     deleteKeys(ElementAnimationStepOptionsIn, [
-      'start', 'delta', 'target', 'dissolve',
+      'start', 'delta', 'target', 'dissolve', 'setColorFrom',
     ]);
     super(ElementAnimationStepOptionsIn);
     const defaultPositionOptions = {
@@ -122,11 +124,12 @@ export class ColorAnimationStep extends ElementAnimationStep {
       target: null,
       delta: null,
       dissolve: null,
+      setColorFrom: null,
     };
     const optionsToUse = joinObjects<any>({}, defaultPositionOptions, ...options);
     this.color = {} as any;
     copyKeysFromTo(optionsToUse, this.color, [
-      'start', 'delta', 'target', 'dissolve',
+      'start', 'delta', 'target', 'dissolve', 'setColorFrom',
     ]);
     if ((this.color.target as any) === 'dim') {
       if (this.element != null) {
@@ -177,7 +180,7 @@ export class ColorAnimationStep extends ElementAnimationStep {
       }
       if (this.color.dissolve === 'in') {
         this.color.start[3] = 0.001;
-        element.setColor(this.color.start, this.color.setDefault);
+        element.setColor(this.color.start, this.color.setDefault, this.color.setColorFrom);
         element.showAll();
       }
       this.color.delta = subtractColors(this.color.target, this.color.start);
@@ -204,14 +207,14 @@ export class ColorAnimationStep extends ElementAnimationStep {
       return newColor;
     });
     if (this.element != null) {
-      this.element.setColor(next, this.color.setDefault);
+      this.element.setColor(next, this.color.setDefault, this.color.setColorFrom);
     }
   }
 
   override setToEnd() {
     const { element } = this;
     if (element != null) {
-      element.setColor(this.color.whenComplete, this.color.setDefault);
+      element.setColor(this.color.whenComplete, this.color.setDefault, this.color.setColorFrom);
       if (this.color.dissolve === 'out') {
         element.hide();
       }

--- a/src/js/figure/Animation/AnimationStep/ElementAnimationStep/OpacityAnimationStep.ts
+++ b/src/js/figure/Animation/AnimationStep/ElementAnimationStep/OpacityAnimationStep.ts
@@ -31,6 +31,7 @@ export type OBJ_OpacityAnimationStep = {
   delta?: number;      // delta overrides target if both are defined
   dissolve?: 'in' | 'out' | null;
   dissolveFromCurrent?: boolean;
+  skipFormIgnored?: boolean;
 } & OBJ_ElementAnimationStep;
 
 /**
@@ -119,6 +120,7 @@ export class OpacityAnimationStep extends ElementAnimationStep {
     whenComplete: number;  // Color after dissolving
     dissolve?: 'in' | 'out' | null;
     dissolveFromCurrent: boolean;
+    skipFormIgnored: boolean;
   };
 
   /**
@@ -128,7 +130,7 @@ export class OpacityAnimationStep extends ElementAnimationStep {
     const ElementAnimationStepOptionsIn =
       joinObjects<any>({}, ...optionsIn, { type: 'opacity' });
     deleteKeys(ElementAnimationStepOptionsIn, [
-      'start', 'delta', 'target', 'dissolve', 'dissolveFromCurrent',
+      'start', 'delta', 'target', 'dissolve', 'dissolveFromCurrent', 'skipFormIgnored',
     ]);
     super(ElementAnimationStepOptionsIn);
     const defaultPositionOptions = {
@@ -137,11 +139,12 @@ export class OpacityAnimationStep extends ElementAnimationStep {
       delta: null,
       dissolve: null,
       dissolveFromCurrent: false,
+      skipFormIgnored: false,
     };
     const options = joinObjects<any>({}, defaultPositionOptions, ...optionsIn);
     this.opacity = {} as any;
     copyKeysFromTo(options, this.opacity, [
-      'start', 'delta', 'target', 'dissolve', 'dissolveFromCurrent',
+      'start', 'delta', 'target', 'dissolve', 'dissolveFromCurrent', 'skipFormIgnored',
     ]);
   }
 
@@ -204,7 +207,7 @@ export class OpacityAnimationStep extends ElementAnimationStep {
         // this.opacity.start = 0.001;
         this.opacity.target = 1;
         this.opacity.whenComplete = 1;
-        element.showAll();
+        element.showAll(this.opacity.skipFormIgnored);
         element.setOpacity(this.opacity.start);
       }
       this.opacity.delta = this.opacity.target - this.opacity.start;

--- a/src/js/figure/Element.ts
+++ b/src/js/figure/Element.ts
@@ -3795,7 +3795,8 @@ class FigureElement {
     }
   }
 
-  showAll(): void {
+  // eslint-disable-next-line no-unused-vars
+  showAll(skipFormIgnored: boolean = false): void {
     this.show();
   }
 
@@ -5624,11 +5625,15 @@ class FigureElementCollection extends FigureElement {
     this.show(toShow);
   }
 
-  override showAll(): void {
+  override showAll(skipFormIgnored: boolean = false): void {
     super.show();
     for (let i = 0, j = this.drawOrder.length; i < j; i += 1) {
       const element = this.elements[this.drawOrder[i]];
-      element.showAll();
+      // When skipFormIgnored is set (form-driven shows), leave form-ignored
+      // descendant subtrees untouched so their visibility persists.
+      if (!(skipFormIgnored && element.isFormIgnored)) {
+        element.showAll(skipFormIgnored);
+      }
     }
   }
 
@@ -5972,7 +5977,11 @@ class FigureElementCollection extends FigureElement {
 
     for (let i = 0; i < this.drawOrder.length; i += 1) {
       const element = this.elements[this.drawOrder[i]];
-      if (!this.preserveChildColor) {
+      // A form-ignored child (and its subtree) is excluded from the equation's
+      // default ('form') colour cascade so its colour persists across form
+      // changes, matching the isFormIgnored "no form-driven changes" contract.
+      const formIgnored = from === 'form' && element.isFormIgnored;
+      if (!this.preserveChildColor && !formIgnored) {
         element.setColor(nonNullColor, setDefault, from);
       }
     }
@@ -6063,11 +6072,11 @@ class FigureElementCollection extends FigureElement {
     }
   }
 
-  setElementColors(elementColors: Record<string, any>) {
+  setElementColors(elementColors: Record<string, any>, from: string | null = null) {
     for (let i = 0; i < this.drawOrder.length; i += 1) {
       const element = this.elements[this.drawOrder[i]];
       if (element.name in elementColors) {
-        element.setColor(elementColors[element.name]);
+        element.setColor(elementColors[element.name], true, from);
       }
     }
   }
@@ -6138,6 +6147,7 @@ class FigureElementCollection extends FigureElement {
     delay: number = 0,
     callback: (string | ((arg: any | null | undefined) => void)) | null | undefined = null,
     name: string = '',
+    from: string | null = null,
     easeFunction: string | ((n: number) => number) = 'tools.math.linear',
   ) {
     let callbackMethod = callback;
@@ -6154,6 +6164,7 @@ class FigureElementCollection extends FigureElement {
                 duration: time,
                 progression: easeFunction as any,
                 onFinish: callbackMethod as any,
+                setColorFrom: from,
               })
               .start();
             // only want to send callback once
@@ -6161,7 +6172,7 @@ class FigureElementCollection extends FigureElement {
             timeToAnimate = time + delay;
           }
         } else {
-          element.setColor(elementColors[element.name]);
+          element.setColor(elementColors[element.name], true, from);
         }
       }
     }

--- a/src/js/figure/Equation/EquationAnimations.test.ts
+++ b/src/js/figure/Equation/EquationAnimations.test.ts
@@ -431,6 +431,155 @@ describe('Equation Animation', () => {
       const state2 = c._state({ ignoreShown: true, returnF1Type: false });
       expect(state2.isFormIgnored).toBe(false);
     });
+
+    test('showForm does not show ignored child inside a shown collection', () => {
+      figure.add([{
+        name: 'coll',
+        make: 'collection',
+        elements: [
+          { name: 'keep', make: 'polygon' },
+          { name: 'ignore', make: 'polygon' },
+        ],
+      }]);
+      const coll = figure.elements._coll;
+      const keep = coll._keep;
+      const ignore = coll._ignore;
+
+      figure.add([{
+        name: 'eqn2',
+        make: 'equation',
+        options: {
+          elements: { coll },
+          forms: { withColl: ['coll'] },
+        },
+      }]);
+      const e = figure.elements._eqn2;
+
+      // The collection is a form element; flag and hide one child so the form
+      // must leave it untouched even though it shows the parent collection.
+      ignore.isFormIgnored = true;
+      ignore.hide();
+
+      e.showForm('withColl');
+      figure.drawNow(0);
+
+      expect(coll.isShown).toBe(true);
+      expect(keep.isShown).toBe(true);
+      expect(ignore.isShown).toBe(false);
+    });
+
+    test('dissolve-in form change does not show ignored child inside a collection', () => {
+      figure.add([{
+        name: 'coll',
+        make: 'collection',
+        elements: [
+          { name: 'keep', make: 'polygon' },
+          { name: 'ignore', make: 'polygon' },
+        ],
+      }]);
+      const coll = figure.elements._coll;
+      const ignore = coll._ignore;
+
+      figure.add([{
+        name: 'eqn2',
+        make: 'equation',
+        options: {
+          elements: { coll },
+          forms: { empty: [], withColl: ['coll'] },
+        },
+      }]);
+      const e = figure.elements._eqn2;
+
+      e.showForm('empty');
+      figure.drawNow(0);
+
+      ignore.isFormIgnored = true;
+      ignore.hide();
+
+      e.goToForm({ form: 'withColl', animate: 'dissolve', duration: 1 });
+      figure.drawNow(0);
+      figure.drawNow(0.5);
+      figure.drawNow(2);
+
+      expect(coll.isShown).toBe(true);
+      expect(ignore.isShown).toBe(false);
+      expect(ignore.animations.animations).toHaveLength(0);
+    });
+
+    test('showForm does not recolor ignored child inside a collection', () => {
+      figure.add([{
+        name: 'coll',
+        make: 'collection',
+        elements: [
+          { name: 'keep', make: 'polygon' },
+          { name: 'ignore', make: 'polygon' },
+        ],
+      }]);
+      const coll = figure.elements._coll;
+      const keep = coll._keep;
+      const ignore = coll._ignore;
+
+      figure.add([{
+        name: 'eqn2',
+        make: 'equation',
+        options: {
+          color: [1, 0, 0, 1],
+          elements: { coll },
+          forms: { withColl: ['coll'] },
+        },
+      }]);
+      const e = figure.elements._eqn2;
+
+      const ignoreColor = [0, 1, 0, 1];
+      ignore.isFormIgnored = true;
+      ignore.setColor(ignoreColor);
+
+      e.showForm('withColl');
+      figure.drawNow(0);
+
+      // keep inherits the equation's 'form' colour; ignore keeps its own.
+      expect(keep.color).toEqual([1, 0, 0, 1]);
+      expect(ignore.color).toEqual(ignoreColor);
+    });
+
+    test('animated goToForm does not recolor ignored child inside a collection', () => {
+      figure.add([{
+        name: 'coll',
+        make: 'collection',
+        elements: [
+          { name: 'keep', make: 'polygon' },
+          { name: 'ignore', make: 'polygon' },
+        ],
+      }]);
+      const coll = figure.elements._coll;
+      const ignore = coll._ignore;
+
+      figure.add([{
+        name: 'eqn2',
+        make: 'equation',
+        options: {
+          color: [1, 0, 0, 1],
+          elements: { coll },
+          forms: { other: [], withColl: ['coll'] },
+        },
+      }]);
+      const e = figure.elements._eqn2;
+
+      e.showForm('other');
+      figure.drawNow(0);
+
+      const ignoreColor = [0, 1, 0, 1];
+      ignore.isFormIgnored = true;
+      ignore.setColor(ignoreColor);
+
+      e.goToForm({ form: 'withColl', animate: 'move', duration: 1 });
+      figure.drawNow(0);
+      figure.drawNow(0.5);
+      figure.drawNow(2);
+
+      expect(ignore.color).toEqual(ignoreColor);
+      expect(ignore.animations.animations).toHaveLength(0);
+    });
   });
 
   describe('formChanged notification', () => {

--- a/src/js/figure/Equation/EquationForm.ts
+++ b/src/js/figure/Equation/EquationForm.ts
@@ -77,7 +77,7 @@ export type TypeCollectionMethods = {
   getElementTransforms: () => { [key: string]: Transform },
   getElementColors: (includeHidden: boolean) => { [key: string]: TypeColor },
   setElementTransforms: (transforms: { [key: string]: Transform }) => void,
-  setElementColors: (colors: { [key: string]: TypeColor }) => void,
+  setElementColors: (colors: { [key: string]: TypeColor }, from?: string | null) => void,
   animateToTransforms(
     elementTransforms: Record<string, any>,
     time?: number,
@@ -92,6 +92,7 @@ export type TypeCollectionMethods = {
     delay?: number,
     callback?: string | ((arg?: any) => void) | null,
     name?: string,
+    from?: string | null,
     easeFunction?: string | ((n: number) => number)): number,
 };
 
@@ -592,7 +593,7 @@ export default class EquationForm extends Elements {
     elements.forEach((e) => {
       (e.animations.addTo('_EquationColor') as any)
         .opacity({
-          dissolve, onFinish, duration: time, delay, completeOnCancel: true,
+          dissolve, onFinish, duration: time, delay, completeOnCancel: true, skipFormIgnored: true,
         })
         .start();
     });
@@ -632,7 +633,7 @@ export default class EquationForm extends Elements {
     const { show, hide } = this.getElementsToShowAndHide();
     if (showTime === 0) {
       show.forEach((e) => {
-        e.showAll();
+        e.showAll(true);
       });
     } else {
       this.dissolveElements(show, 'in', 0.01, showTime, null);
@@ -663,7 +664,7 @@ export default class EquationForm extends Elements {
     }
     if (showTime === 0) {
       show.forEach((e) => {
-        e.showAll();
+        e.showAll(true);
       });
       if (callback != null) {
         callback();
@@ -732,14 +733,14 @@ export default class EquationForm extends Elements {
     elementsToDelayShowing.forEach((e) => {
       (e.animations.addTo('_EquationColor') as any)
         .dissolveIn({
-          duration: showTime, onFinish, delay: cumTime + blankTime,
+          duration: showTime, onFinish, delay: cumTime + blankTime, skipFormIgnored: true,
         })
         .start();
     });
     elementsToShowAfterDissolve.forEach((e) => {
       (e.animations.addTo('_EquationColor') as any)
         .dissolveIn({
-          duration: showTime, onFinish, delay: blankTime,
+          duration: showTime, onFinish, delay: blankTime, skipFormIgnored: true,
         })
         .start();
     });
@@ -871,8 +872,8 @@ export default class EquationForm extends Elements {
     }
     this.collectionMethods.setElementTransforms(currentTransforms);
     this.collectionMethods.setElementTransforms(toShowTransforms);
-    this.collectionMethods.setElementColors(currentColors);
-    this.collectionMethods.setElementColors(toShowColors);
+    this.collectionMethods.setElementColors(currentColors, 'form');
+    this.collectionMethods.setElementColors(toShowColors, 'form');
 
     let cumTime = delay;
 
@@ -915,7 +916,7 @@ export default class EquationForm extends Elements {
         && elementsToMove.length === 0
       ) {
         this.collectionMethods.animateToColors(
-          animateToColors, dissolveOutTime, delay, null, '_EquationAnimateColor',
+          animateToColors, dissolveOutTime, delay, null, '_EquationAnimateColor', 'form',
         );
         colorAnimationsStarted = true;
       }
@@ -966,7 +967,7 @@ export default class EquationForm extends Elements {
       if (elementsToShow.length > 0) {
         if (elementsToChangeColor.length > 0) {
           this.collectionMethods.animateToColors(
-            animateToColors, dissolveOutTime, cumTime, null, '_EquationAnimateColor',
+            animateToColors, dissolveOutTime, cumTime, null, '_EquationAnimateColor', 'form',
           );
           colorAnimationsStarted = true;
         }
@@ -981,7 +982,7 @@ export default class EquationForm extends Elements {
       && !colorAnimationsStarted
     ) {
       this.collectionMethods.animateToColors(
-        animateToColors, dissolveOutTime, cumTime, null, '_EquationAnimateColor',
+        animateToColors, dissolveOutTime, cumTime, null, '_EquationAnimateColor', 'form',
       );
       colorAnimationsStarted = true;
     }
@@ -1005,7 +1006,7 @@ export default class EquationForm extends Elements {
       if (elementsToShow.length > 0) {
         if (elementsToChangeColor.length > 0) {
           this.collectionMethods.animateToColors(
-            animateToColors, dissolveInTime, cumTime, null, '_EquationAnimateColor',
+            animateToColors, dissolveInTime, cumTime, null, '_EquationAnimateColor', 'form',
           );
           colorAnimationsStarted = true;
         }
@@ -1028,7 +1029,7 @@ export default class EquationForm extends Elements {
       && !colorAnimationsStarted
     ) {
       cumTime += this.collectionMethods.animateToColors(
-        animateToColors, dissolveInTime, cumTime, colorCallback, '_EquationAnimateColor',
+        animateToColors, dissolveInTime, cumTime, colorCallback, '_EquationAnimateColor', 'form',
       );
       colorAnimationsStarted = true;
     }

--- a/src/js/figure/FigureCollections/Angle.ts
+++ b/src/js/figure/FigureCollections/Angle.ts
@@ -1875,8 +1875,8 @@ class CollectionsAngle extends FigureElementCollection {
     this.animateNextFrame();
   }
 
-  override showAll() {
-    super.showAll();
+  override showAll(skipFormIgnored: boolean = false) {
+    super.showAll(skipFormIgnored);
     this.update();
   }
 


### PR DESCRIPTION
## Summary
- Fix `isFormIgnored` not protecting an element nested inside a `FigureElementCollection` that is itself a form element — showing the form previously revealed the flagged subtree via `showAll` and recolored it via the default colour cascade
- Form-driven shows (immediate and dissolve-in) now skip form-ignored descendant subtrees via a `skipFormIgnored` flag threaded through `showAll`/`OpacityAnimationStep`; the form colour cascade (immediate, animated `move`, `setElementColors`) carries `'form'` provenance so `setColor` skips form-ignored descendants too
- Forward `skipFormIgnored` through `Angle.showAll` so the fix holds for `Angle` form elements
- Add 4 tests covering nested show, dissolve-in show, immediate recolor, and animated recolor; `tsc` clean, EquationAnimations 19/19 and Angle 222/222 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)